### PR TITLE
Skip tick if not enough cpu

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,10 @@ if (config.profiler.enabled) {
 }
 
 var main = function() {
+  if (Game.cpu.bucket < Game.cpu.tickLimit * 2) {
+    console.log('Skipping tick ' + Game.time + ' due to lack of CPU.');
+    return;
+  }
   brain.prepareMemory();
   brain.handleNextroom();
   brain.handleSquadmanager();


### PR DESCRIPTION
Will skip a tick instead of using all the cpu then erroring.
Eventually it will save up enough cpu to run a tick, then become stable in only running once every several ticks, instead of erroring every single tick.