### PR TITLE
Add external supply to queue

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -80,7 +80,9 @@ global.config = {
   },
 
   carry: {
-    size: 200
+    size: 200,
+    carryPercentageBase: 0.2,
+    carryPercentageExtern: 0.5
   },
 
   creep: {

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -94,7 +94,18 @@ Room.prototype.spawnCheckForCreate = function(creepsConfig) {
         }
         return 4;
       }
-
+      // add external supply in front of the other
+            if (target !== room.name) {
+              if (object.role == 'carry' ) {
+                return 4;
+              }
+              if (object.role == 'sourcer' ) {
+                return 5;
+              }
+              if (object.role == 'reserver' ) {
+                return 6;
+              }
+            }
       if (object.role == 'nextroomer') {
         return 11;
       }

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -94,18 +94,18 @@ Room.prototype.spawnCheckForCreate = function(creepsConfig) {
         }
         return 4;
       }
-      // add external supply in front of the other
-            if (target !== room.name) {
-              if (object.role == 'carry' ) {
-                return 4;
-              }
-              if (object.role == 'sourcer' ) {
-                return 5;
-              }
-              if (object.role == 'reserver' ) {
-                return 6;
-              }
-            }
+      // spawn reserver after external supply line
+      if (target !== room.name) {
+        if (object.role == 'carry') {
+          return 5;
+        }
+        if (object.role == 'sourcer') {
+          return 6;
+        }
+        if (object.role == 'reserver') {
+          return 7;
+        }
+      }
       if (object.role == 'nextroomer') {
         return 11;
       }

--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -68,13 +68,13 @@ roles.carry.preMove = function(creep, directions) {
   if (!creep.memory.routing.reverse) {
     reverse = creep.checkForTransfer(directions.forwardDirection);
   }
-  // less twiddling around
+  // define minimum carryPercentage to move back to storage
   let carryPercentage = 0.1;
   if (creep.room.name == creep.memory.routing.targetRoom) {
-    carryPercentage = 0.5;
+    carryPercentage = config.carry.carryPercentageExtern;
   }
   if (creep.room.name == creep.memory.base) {
-    carryPercentage = 0.2;
+    carryPercentage = config.carry.carryPercentageBase;
   }
 
   if (_.sum(creep.carry) > carryPercentage * creep.carryCapacity) {

--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -68,13 +68,13 @@ roles.carry.preMove = function(creep, directions) {
   if (!creep.memory.routing.reverse) {
     reverse = creep.checkForTransfer(directions.forwardDirection);
   }
-
+  // less twiddling around
   let carryPercentage = 0.1;
   if (creep.room.name == creep.memory.routing.targetRoom) {
-    carryPercentage = 0.8;
+    carryPercentage = 0.5;
   }
   if (creep.room.name == creep.memory.base) {
-    carryPercentage = 0.0;
+    carryPercentage = 0.2;
   }
 
   if (_.sum(creep.carry) > carryPercentage * creep.carryCapacity) {


### PR DESCRIPTION
Spawn 'reserver' after 'carry' and 'sourcer' to constantly have the
external supply lines running.
Change carryPercentage for less jumping around at one spot.

Testing on live