### PR TITLE
[WIP] Costmatrix improvements

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -5,6 +5,25 @@ function getOppositeDirection(direction) {
   return ((direction + 3) % 8) + 1;
 }
 
+Creep.prototype.moveToMy = function(target, range) {
+  range = range || 0;
+  let search = PathFinder.search(
+    this.pos, {
+      pos: target,
+      range: range
+    }, {
+      roomCallback: this.room.getCostMatrixCallback(target, true),
+      maxRooms: 0
+    }
+  );
+
+  if (search.incomplete) {
+    this.moveRandom();
+    return false;
+  }
+  return this.move(this.pos.getDirectionTo(search.path[0]));
+};
+
 Creep.prototype.inBase = function() {
   return this.room.name == this.memory.base;
 };
@@ -254,11 +273,7 @@ Creep.prototype.getPositionInPath = function(target) {
 
     this.memory.path[this.room.name] = this.room.findPath(start, end, {
       ignoreCreeps: true,
-      costCallback: this.room.getAvoids(this.room, {
-        controller: true,
-        power: true,
-        filler: true
-      })
+      costCallback: this.room.getCostMatrixCallback(end, true)
     });
   }
   var path = this.memory.path[this.room.name];

--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -96,7 +96,7 @@ Creep.prototype.spawnCarry = function() {
       this.memory.wait = 0;
     }
     if (this.memory.wait <= 0) {
-      Game.rooms[this.memory.base].memory.queue.push(spawn);
+      Game.rooms[this.memory.base].checkRoleToSpawn('carry', 2, this.memory.routing.targetId, this.memory.routing.targetRoom);
       this.memory.wait = waitTime;
     }
   }

--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -58,18 +58,6 @@ Creep.prototype.handleMineralCreep = function() {
     creep.memory.state = (creep.memory.state + 1) % states.length;
   }
 
-  function moveTo(creep, target) {
-    let search = PathFinder.search(
-      creep.pos, {
-        pos: target.pos,
-        range: 1
-      }, {
-        roomCallback: creep.room.getAvoids(creep.room, {}, true),
-      }
-    );
-    let returnCode = creep.move(creep.pos.getDirectionTo(search.path[0]));
-  }
-
   function get(creep, target, resource) {
     if (_.sum(creep.carry) == creep.carryCapacity) {
       //    creep.log('next state no capacity' + target);
@@ -141,10 +129,9 @@ Creep.prototype.handleMineralCreep = function() {
   function cleanUpLabs(creep) {
     creep.say('cleanup');
     if (_.sum(creep.carry) > 0) {
-      creep.moveTo(creep.room.terminal, {
-        ignoreCreeps: true,
-        costCallback: creep.room.getAvoids(creep.room)
-      });
+
+      let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
       for (let resource in creep.carry) {
         if (creep.carry[resource] === 0) {
           continue;
@@ -170,11 +157,9 @@ Creep.prototype.handleMineralCreep = function() {
         creep.moveRandom();
         return false;
       }
-      creep.moveTo(lab, {
-        ignoreCreeps: true,
-        costCallback: creep.room.getAvoids(creep.room)
-      });
-      let returnCode = creep.withdraw(lab, lab.mineralType);
+      let returnCode = creep.moveToMy(lab.pos);
+
+      returnCode = creep.withdraw(lab, lab.mineralType);
       //    creep.log(returnCode + ' ' + lab.mineralType + ' ' + JSON.stringify(lab));
     }
   }
@@ -284,23 +269,18 @@ Creep.prototype.handleMineralCreep = function() {
     if (lab.energy < lab.energyCapacity) {
       creep.say('boost');
       if (creep.carry.energy > 0) {
-        creep.moveTo(lab, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(lab.pos);
         creep.transfer(lab, RESOURCE_ENERGY);
         return true;
       } else {
-        creep.moveTo(creep.room.storage, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(creep.room.storage.pos);
+
         if (_.sum(creep.carry) > 0) {
           for (let resource in creep.carry) {
             creep.transfer(creep.room.storage, resource);
           }
         }
-        let returnCode = creep.withdraw(creep.room.storage, RESOURCE_ENERGY);
+        returnCode = creep.withdraw(creep.room.storage, RESOURCE_ENERGY);
         return true;
       }
     }
@@ -308,10 +288,8 @@ Creep.prototype.handleMineralCreep = function() {
     if (lab.mineralAmount < lab.mineralCapacity) {
       creep.say('mineral');
       if (creep.carry[creep.memory.boostAction.mineral] > 0) {
-        creep.moveTo(lab, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(lab.pos);
+
         creep.transfer(lab, creep.memory.boostAction.mineral);
         return true;
       } else {
@@ -319,10 +297,9 @@ Creep.prototype.handleMineralCreep = function() {
           //        creep.log('For boosting ' + creep.memory.boostAction.mineral + ' not available');
           return false;
         }
-        creep.moveTo(creep.room.terminal, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+
+        let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
         creep.withdraw(creep.room.terminal, creep.memory.boostAction.mineral);
         return true;
       }
@@ -340,21 +317,15 @@ Creep.prototype.handleMineralCreep = function() {
     // TODO Transfer to structures
 
     if (creep.carry.energy === 0) {
-      creep.moveTo(creep.room.terminal.pos, {
-        ignoreCreeps: true,
-        costCallback: creep.room.getAvoids(creep.room)
-      });
+      let returnCode = creep.moveToMy(creep.room.terminal.pos);
       for (let resource in creep.carry) {
         creep.transfer(creep.room.terminal, resource);
       }
       creep.withdraw(creep.room.terminal, RESOURCE_ENERGY);
       return true;
     }
+    let returnCode = creep.moveToMy(creep.room.storage.pos);
 
-    creep.moveTo(creep.room.storage.pos, {
-      ignoreCreeps: true,
-      costCallback: creep.room.getAvoids(creep.room)
-    });
     creep.transfer(creep.room.storage, RESOURCE_ENERGY);
     return true;
   }
@@ -375,10 +346,8 @@ Creep.prototype.handleMineralCreep = function() {
     creep.say('checkStorage');
 
     if (_.sum(creep.carry) > 0) {
-      creep.moveTo(creep.room.terminal.pos, {
-        ignoreCreeps: true,
-        costCallback: creep.room.getAvoids(creep.room)
-      });
+      let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
       for (let transfer in creep.carry) {
         let returnCode = creep.transfer(creep.room.terminal, transfer);
         if (returnCode == OK || returnCode == ERR_NOT_IN_RANGE) {
@@ -388,11 +357,8 @@ Creep.prototype.handleMineralCreep = function() {
       }
       return true;
     }
+    let returnCode = creep.moveToMy(creep.room.storage.pos);
 
-    creep.moveTo(creep.room.storage.pos, {
-      ignoreCreeps: true,
-      costCallback: creep.room.getAvoids(creep.room)
-    });
     creep.withdraw(creep.room.storage, resource);
     return true;
   }
@@ -408,16 +374,11 @@ Creep.prototype.handleMineralCreep = function() {
         let nuker = nukers[0];
         if (nuker.ghodium < nuker.ghodiumCapacity) {
           if (creep.carry[RESOURCE_GHODIUM] > 0) {
-            creep.moveTo(nuker, {
-              ignoreCreeps: true,
-              costCallback: creep.room.getAvoids(creep.room)
-            });
+            let returnCode = creep.moveToMy(nuker.pos);
             creep.transfer(nuker, RESOURCE_GHODIUM);
           } else {
-            creep.moveTo(creep.room.terminal, {
-              ignoreCreeps: true,
-              costCallback: creep.room.getAvoids(creep.room)
-            });
+            let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
             creep.withdraw(creep.room.terminal, RESOURCE_GHODIUM);
           }
           return true;
@@ -474,10 +435,8 @@ Creep.prototype.handleMineralCreep = function() {
 
     if (room.memory.terminalTooLessEnergy) {
       if (_.sum(creep.carry) - creep.carry.energy > 0) {
-        creep.moveTo(room.terminal, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
         for (let resource in creep.carry) {
           creep.transfer(room.terminal, resource);
         }
@@ -486,16 +445,11 @@ Creep.prototype.handleMineralCreep = function() {
 
       creep.say('TEnergy');
       if (creep.carry.energy > 0) {
-        creep.moveTo(room.terminal, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(creep.room.terminal.pos);
+
         creep.transfer(room.terminal, RESOURCE_ENERGY);
       } else {
-        creep.moveTo(room.storage, {
-          ignoreCreeps: true,
-          costCallback: creep.room.getAvoids(creep.room)
-        });
+        let returnCode = creep.moveToMy(creep.room.storage.pos);
         creep.withdraw(room.storage, RESOURCE_ENERGY);
       }
       return true;
@@ -519,10 +473,8 @@ Creep.prototype.handleMineralCreep = function() {
     } else if (state.destination == STRUCTURE_STORAGE) {
       target = creep.room.storage;
     }
-    moveTo(creep, target, {
-      ignoreCreeps: true,
-      costCallback: creep.room.getAvoids(creep.room)
-    });
+
+    creep.moveToMy(target.pos);
 
     let resource = RESOURCE_ENERGY;
     if (state.resouce != 'energy') {
@@ -588,18 +540,8 @@ Creep.prototype.boost = function() {
             room.memory.boosting[boost][this.id] = true;
 
             if (labs.length > 0) {
-              let search = PathFinder.search(
-                this.pos, {
-                  pos: labs[0].pos,
-                  range: 1
-                }, {
-                  roomCallback: this.room.getAvoids(this.room, {}, true),
-                  maxRooms: 1
-                }
-              );
-
-              this.move(this.pos.getDirectionTo(search.path[0]));
-              let returnCode = labs[0].boostCreep(this);
+              let returnCode = this.moveToMy(labs[0].pos, 1);
+              returnCode = labs[0].boostCreep(this);
               if (returnCode == OK) {
                 let room = Game.rooms[this.room.name];
                 delete room.memory.boosting[boost][this.id];

--- a/src/prototype_creep_routing.js
+++ b/src/prototype_creep_routing.js
@@ -232,47 +232,6 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, skipPreM
       }
     }
     // TODO ?? This is the place where I get back to the path ??
-    let callback = this.room.getMatrixCallback;
-
-    if (this.room.memory.costMatrix && this.room.memory.costMatrix.base) {
-      // this.log('base matrix: ' +
-      // PathFinder.CostMatrix.deserialize(this.room.memory.costMatrix.base).get(28,
-      // 13));
-      let room = this.room;
-      callback = function(end) {
-        let callbackInner = function(roomName) {
-          let costMatrix = PathFinder.CostMatrix.deserialize(room.memory.costMatrix.base);
-
-          // TODO excluding structures, for the case where the spawn is in the wrong spot (I guess this can be handled better)
-          let structures = room.find(FIND_STRUCTURES, {
-            filter: function(object) {
-              if (object.structureType == STRUCTURE_RAMPART) {
-                return false;
-              }
-              if (object.structureType == STRUCTURE_ROAD) {
-                return false;
-              }
-              if (object.structureType == STRUCTURE_CONTAINER) {
-                return false;
-              }
-              return true;
-            }
-          });
-          for (let structure of structures) {
-            costMatrix.set(structure.pos.x, structure.pos.y, config.layout.structureAvoid);
-          }
-
-          return costMatrix;
-        };
-        return callbackInner;
-      };
-    }
-    // this.log('matrix: ' +
-    // PathFinder.CostMatrix.deserialize(this.room.memory.costMatrix.base).get(19,
-    // 24));
-    // this.log('storage: ' +
-    // JSON.stringify(this.room.memory.position.structure.storage));
-
     if (path.length === 0) {
       this.log('config_creep_routing.followPath no pos: ' + JSON.stringify(path));
       return false;
@@ -293,7 +252,7 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, skipPreM
         pos: posFirst,
         range: 0
       }, {
-        roomCallback: callback(posFirst),
+        roomCallback: this.room.getCostMatrixCallback(posFirst, true),
         maxRooms: 1
       }
     );

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -22,22 +22,7 @@ Creep.upgradeControllerTask = function(creep) {
     creep.moveRandomWithin(creep.room.controller.pos);
     return true;
   } else {
-    let search = PathFinder.search(
-      creep.pos, {
-        pos: creep.room.controller.pos,
-        range: 3
-      }, {
-        roomCallback: creep.room.getAvoids(creep.room, {}, true),
-        maxRooms: 0
-      }
-    );
-
-    if (search.incomplete) {
-      creep.say('incomplete');
-      creep.moveTo(creep.room.controller.pos);
-      return true;
-    }
-    creep.move(creep.pos.getDirectionTo(search.path[0]));
+    creep.moveToMy(creep.room.controller.pos, 3);
   }
   return true;
 };
@@ -107,9 +92,7 @@ Creep.recycleCreep = function(creep) {
     }
   });
   if (spawn !== null) {
-    creep.moveTo(spawn, {
-      ignoreCreeps: true
-    });
+    creep.moveToMy(spawn.pos);
     spawn.recycleCreep(creep);
   }
   // TODO move back
@@ -163,7 +146,7 @@ Creep.prototype.getEnergyFromHostileStructures = function() {
   }
 
   let range = this.pos.getRangeTo(structure);
-  this.moveTo(structure);
+  this.moveToMy(structure.pos);
   this.withdraw(structure, RESOURCE_ENERGY);
   return true;
 };
@@ -181,25 +164,7 @@ Creep.prototype.getEnergyFromStorage = function() {
   if (range == 1) {
     this.withdraw(this.room.storage, RESOURCE_ENERGY);
   } else {
-    let search = PathFinder.search(
-      this.pos, {
-        pos: this.room.storage.pos,
-        range: 1
-      }, {
-        roomCallback: this.room.getAvoids(this.room, {}, true),
-      }
-    );
-    if (search.incomplete) {
-      this.say('incomplete', true);
-      this.moveTo(this.room.storage.pos, {
-        ignoreCreeps: true
-      });
-      return true;
-    }
-    let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
-    if (returnCode != OK && returnCode != ERR_TIRED) {
-      // this.log(`getEnergyFromStorage: ${returnCode}`);
-    }
+    this.moveToMy(this.room.storage.pos, 1);
   }
   return true;
 };
@@ -219,28 +184,7 @@ Creep.prototype.repairStructure = function() {
 
     if (to_repair instanceof ConstructionSite) {
       this.build(to_repair);
-
-      let search = PathFinder.search(
-        this.pos, {
-          pos: to_repair.pos,
-          range: 3
-        }, {
-          roomCallback: this.room.getAvoids(this.room, {}, true),
-          maxRooms: 0
-        }
-      );
-
-      if (search.incomplete) {
-        this.moveTo(to_repair);
-        return true;
-      }
-
-      if (!this.pos.getDirectionTo(search.path[0])) {
-        this.moveRandom();
-        return true;
-      }
-
-      let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
+      this.moveToMy(to_repair.pos, 3);
       return true;
     } else if (to_repair.hits < 10000 || to_repair.hits < this.memory.step + 10000) {
       this.repair(to_repair);
@@ -249,42 +193,12 @@ Creep.prototype.repairStructure = function() {
         if (range <= 3) {
           this.moveRandomWithin(to_repair);
         } else {
-          let search = PathFinder.search(
-            this.pos, {
-              pos: to_repair.pos,
-              range: 3
-            }, {
-              roomCallback: this.room.getAvoids(this.room, {}, true),
-              maxRooms: 0
-            }
-          );
-
-          if (!this.pos.getDirectionTo(search.path[0])) {
-            this.moveRandom();
-            return true;
-          }
-
-          if (search.incomplete) {
-            this.moveTo(to_repair.pos);
-            return true;
-          }
-
-          let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
+          let returnCode = this.moveToMy(to_repair.pos, 3);
           this.memory.lastPosition = this.pos;
           if (returnCode == OK) {
             return true;
           }
-          if (returnCode == ERR_NO_PATH) {
-            this.memory.move_wait = 0;
-            this.log('No path : ' + JSON.stringify(search));
-            returnCode = this.moveTo(to_repair, {
-              ignoreCreeps: true,
-              costCallback: this.room.getAvoids(this.room, {
-                power: true
-              })
-            });
-          }
-          this.log('config_creep_resources.repairStructure moveByPath.returnCode: ' + returnCode + ' search: ' + JSON.stringify(search) + ' start: ' + JSON.stringify(this.pos) + ' end: ' + JSON.stringify(to_repair.pos));
+          this.log('config_creep_resources.repairStructure moveByPath.returnCode: ' + returnCode);
           return true;
         }
       }
@@ -343,17 +257,7 @@ Creep.prototype.repairStructure = function() {
       this.repair(lowRampart);
       this.moveRandomWithin(lowRampart);
     } else {
-      let search = PathFinder.search(
-        this.pos, {
-          pos: lowRampart.pos,
-          range: 3
-        }, {
-          roomCallback: this.room.getAvoids(this.room, {}, true),
-          maxRooms: 0
-        }
-      );
-      //     this.log('LowRampart: ' + lowRamparts[0].pos + ' search: ' + JSON.stringify(search));
-      let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
+      this.moveToMy(lowRampart.pos, 3);
     }
     return true;
   }
@@ -405,24 +309,7 @@ Creep.prototype.repairStructure = function() {
     } else {
       this.memory.move_wait = 0;
     }
-
-    let search = PathFinder.search(
-      this.pos, {
-        pos: target.pos,
-        range: 3
-      }, {
-        roomCallback: this.room.getAvoids(this.room, {}, true),
-        maxRooms: 0
-      }
-    );
-    //    this.log('ConstructionSite: ' + target.pos + ' search: ' + JSON.stringify(search));
-    // for (let x = 19; x < 31; x++) {
-    // for (let y = 2; y < 7; y++) {
-    // let costmatrix = this.room.getAvoids(this.room, {}, true)(this.room.name);
-    // this.log(x + ',' + y + ' ' + costmatrix.get(x, y));
-    // }
-    // }
-    let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
+    this.moveToMy(target.pos, 3);
     this.memory.lastPosition = this.pos;
     this.memory.target = target.id;
     return true;
@@ -477,21 +364,7 @@ Creep.prototype.getDroppedEnergy = function() {
       return true;
     }
     if (target.energy > (energyRange * 10) * (this.carry.energy + 1)) {
-      let search = PathFinder.search(
-        this.pos, {
-          pos: target.pos,
-          range: 1
-        }, {
-          roomCallback: this.room.getAvoids(this.room, {}, true),
-          maxRooms: 0
-        }
-      );
-      if (search.path.length === 0 || search.incomplete) {
-        this.say('deir');
-        this.moveRandom();
-        return true;
-      }
-      let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
+      this.moveToMy(target.pos, 1);
       return true;
     }
   }

--- a/src/prototype_room_basebuilder.js
+++ b/src/prototype_room_basebuilder.js
@@ -104,7 +104,7 @@ Room.prototype.destroyStructure = function(structure) {
 
     // Build ramparts around the spawn if wallThickness > 1
     if (config.layout.wallThickness > 1) {
-      let costMatrixBase = PathFinder.CostMatrix.deserialize(this.memory.costMatrix.base);
+      let costMatrixBase = this.getMemoryCostMatrix();
       let spawns = this.find(FIND_MY_STRUCTURES, {
         filter: function(object) {
           return object.structureType == STRUCTURE_SPAWN;
@@ -130,7 +130,7 @@ Room.prototype.destroyStructure = function(structure) {
           }
         }
       }
-      this.memory.costMatrix.base = costMatrixBase.serialize();
+      this.setMemoryCostMatrix(costMatrixBase);
     }
   }
   return false;

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -2,11 +2,11 @@
 
 Room.prototype.getCostMatrixCallback = function(end, excludeStructures) {
   let callback = this.getMatrixCallback(end);
-  if (this.memory.costMatrix && this.memory.costMatrix.base) {
+  if (cache.rooms[this.name] && cache.rooms[this.name].costMatrix && cache.rooms[this.name].costMatrix.base) {
     let room = this;
     callback = function(end) {
       let callbackInner = function(roomName) {
-        let costMatrix = PathFinder.CostMatrix.deserialize(room.memory.costMatrix.base);
+        let costMatrix = this.getMemoryCostMatrix();
         // TODO the ramparts could be within existing walls (at least when converging to the newmovesim
         costMatrix.set(end.x, end.y, 0);
 

--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -154,7 +154,7 @@ function setStructures(room, path, costMatrixBase) {
       return pathI;
     }
   }
-  room.memory.costMatrix.base = costMatrixBase.serialize();
+  room.setMemoryCostMatrix(costMatrixBase);
 
   return -1;
 }
@@ -181,7 +181,7 @@ let buildCostMatrix = function(room) {
       costMatrixBase.set(pos.x, pos.y, 0xFF);
     }
   }
-  room.memory.costMatrix.base = costMatrixBase.serialize();
+  room.setMemoryCostMatrix(costMatrixBase);
 
   let exits = Game.map.describeExits(room.name);
   if (room.controller) {
@@ -195,7 +195,7 @@ let buildCostMatrix = function(room) {
       for (let pos of path) {
         costMatrixBase.set(pos.x, pos.y, config.layout.pathAvoid);
       }
-      room.memory.costMatrix.base = costMatrixBase.serialize();
+      room.setMemoryCostMatrix(costMatrixBase);
     }
 
     for (let endDir in exits) {
@@ -209,7 +209,7 @@ let buildCostMatrix = function(room) {
       for (let pos of path) {
         costMatrixBase.set(pos.x, pos.y, config.layout.pathAvoid);
       }
-      room.memory.costMatrix.base = costMatrixBase.serialize();
+      room.setMemoryCostMatrix(costMatrixBase);
     }
     return costMatrixBase;
   }
@@ -232,7 +232,7 @@ let buildCostMatrix = function(room) {
       for (let pos of path) {
         costMatrixBase.set(pos.x, pos.y, config.layout.pathAvoid);
       }
-      room.memory.costMatrix.base = costMatrixBase.serialize();
+      room.setMemoryCostMatrix(costMatrixBase);
     }
   }
   return costMatrixBase;

--- a/src/prototype_room_memory.js
+++ b/src/prototype_room_memory.js
@@ -4,10 +4,22 @@
  * Memory abstraction layer
  *
  * The methods build the interface to the memory.
- * Currently only for path
+ * Path:
  * The idea is to cache paths as roomPosition in a global object.
  * Store paths from my rooms in a compressed form in memory.
+ *
+ * CostMatrix:
+ * Store costMatrix for myRooms in cache and memory.
+ * Other rooms are only stored in cache.
  */
+
+Room.prototype.setMemoryCostMatrix = function(costMatrix) {
+
+};
+
+Room.prototype.getMemoryCostMatrix = function() {
+
+};
 
 Room.prototype.getMemoryPaths = function() {
   this.memory.routing = this.memory.routing || {};

--- a/src/prototype_room_memory.js
+++ b/src/prototype_room_memory.js
@@ -14,11 +14,33 @@
  */
 
 Room.prototype.setMemoryCostMatrix = function(costMatrix) {
-
+  if (!cache.rooms[this.name]) {
+    cache.rooms[this.name] = {};
+  }
+  if (!cache.rooms[this.name].costMatrix) {
+    cache.rooms[this.name].costMatrix = {};
+  }
+  if (this.controller.my) {
+    if (!this.memory.costMatrix) {
+      this.memory.costMatrix = {};
+    }
+    this.memory.costMatrix.base = costMatrix.serialize();
+  }
+  cache.rooms[this.name].costMatrix.base = costMatrix;
 };
 
 Room.prototype.getMemoryCostMatrix = function() {
+  if (!cache.rooms[this.name]) {
+    cache.rooms[this.name] = {};
+  }
+  if (!cache.rooms[this.name].costMatrix) {
+    cache.rooms[this.name].costMatrix = {};
+  }
+  if (!cache.rooms[this.name].costMatrix.base) {
+    cache.rooms[this.name].costMatrix.base = PathFinder.CostMatrix.deserialize(this.memory.costMatrix.base);
+  }
 
+  return cache.rooms[this.name].costMatrix.base;
 };
 
 Room.prototype.getMemoryPaths = function() {

--- a/src/prototype_room_routing.js
+++ b/src/prototype_room_routing.js
@@ -36,7 +36,7 @@ Room.prototype.setFillerArea = function(storagePos, costMatrixBase, route) {
     for (let pos of pathFiller) {
       costMatrixBase.set(pos.x, pos.y, config.layout.pathAvoid);
     }
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
 
     let linkStoragePosIterator = fillerPos.findNearPosition();
     for (let linkStoragePos of linkStoragePosIterator) {
@@ -51,7 +51,7 @@ Room.prototype.setFillerArea = function(storagePos, costMatrixBase, route) {
           this.memory.position.structure.tower.push(towerPos);
 
           costMatrixBase.set(fillerPos.x, fillerPos.x, config.layout.creepAvoid);
-          this.memory.costMatrix.base = costMatrixBase.serialize();
+          this.setMemoryCostMatrix(costMatrixBase);
 
           return;
         }
@@ -63,12 +63,10 @@ Room.prototype.setFillerArea = function(storagePos, costMatrixBase, route) {
 Room.prototype.updatePosition = function() {
   // Instead of doing the complete setup, this could also be done on request
   //  this.log('Update position');
+  cache.rooms[this.name] = {};
+  delete this.memory.routing;
 
   let costMatrixBase = this.getCostMatrix();
-
-  if (!this.memory.costMatrix) {
-    this.memory.costMatrix = {};
-  }
 
   this.memory.position = {
     creep: {}
@@ -91,11 +89,10 @@ Room.prototype.updatePosition = function() {
   for (let source of sources) {
     let sourcer = source.pos.findNearPosition().next().value;
     this.memory.position.creep[source.id] = sourcer;
-    // TODO E.g. E11S8 it happens that sourcer has no position
     let link = sourcer.findNearPosition().next().value;
     this.memory.position.structure.link.push(link);
     costMatrixBase.set(link.x, link.y, config.layout.structureAvoid);
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
   }
 
   let minerals = this.find(FIND_MINERALS);
@@ -103,7 +100,7 @@ Room.prototype.updatePosition = function() {
     let extractor = mineral.pos.findNearPosition().next().value;
     this.memory.position.creep[mineral.id] = extractor;
     costMatrixBase.set(extractor.x, extractor.y, config.layout.creepAvoid);
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
   }
 
   if (this.controller) {
@@ -114,13 +111,13 @@ Room.prototype.updatePosition = function() {
     let upgraderPos = this.controller.pos.findNearPosition().next().value;
     this.memory.position.creep[this.controller.id] = upgraderPos;
     costMatrixBase.set(upgraderPos.x, upgraderPos.y, config.layout.creepAvoid);
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
 
     let storagePos = this.memory.position.creep[this.controller.id].findNearPosition().next().value;
     this.memory.position.structure.storage.push(storagePos);
     // TODO should also be done for the other structures
     costMatrixBase.set(storagePos.x, storagePos.y, config.layout.structureAvoid);
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
 
     this.memory.position.creep.pathStart = storagePos.findNearPosition().next().value;
 
@@ -135,7 +132,7 @@ Room.prototype.updatePosition = function() {
       }
       costMatrixBase.set(pos.x, pos.y, config.layout.pathAvoid);
     }
-    this.memory.costMatrix.base = costMatrixBase.serialize();
+    this.setMemoryCostMatrix(costMatrixBase);
 
     for (let source of sources) {
       let route = [{
@@ -153,13 +150,13 @@ Room.prototype.updatePosition = function() {
       }
       let sourcer = this.memory.position.creep[source.id];
       costMatrixBase.set(sourcer.x, sourcer.y, config.layout.creepAvoid);
-      this.memory.costMatrix.base = costMatrixBase.serialize();
+      this.setMemoryCostMatrix(costMatrixBase);
     }
 
     this.setFillerArea(storagePos, costMatrixBase, route);
   }
 
-  this.memory.costMatrix.base = costMatrixBase.serialize();
+  this.setMemoryCostMatrix(costMatrixBase);
   return costMatrixBase;
 };
 

--- a/src/prototype_room_routing.js
+++ b/src/prototype_room_routing.js
@@ -208,25 +208,12 @@ Room.prototype.buildPath = function(route, routePos, from, to) {
   }
 
   // TODO avoid swamps in external rooms
-  let callback = this.getMatrixCallback;
-
-  if (this.memory.costMatrix && this.memory.costMatrix.base) {
-    let room = this;
-    callback = function(end) {
-      let callbackInner = function(roomName) {
-        let costMatrix = PathFinder.CostMatrix.deserialize(room.memory.costMatrix.base);
-        return costMatrix;
-      };
-      return callbackInner;
-    };
-  }
-
   let search = PathFinder.search(
     start, {
       pos: end,
       range: 1
     }, {
-      roomCallback: callback(end),
+      roomCallback: this.getCostMatrixCallback(end),
       maxRooms: 1,
       swampCost: config.layout.swampCost,
       plainCost: config.layout.plainCost
@@ -291,8 +278,8 @@ Room.prototype.getMyExitTo = function(room) {
 
 Room.prototype.getMatrixCallback = function(end) {
   // TODO cache?!
-  //  console.log('getMatrixCallback', this);
   let callback = function(roomName) {
+    // console.log('getMatrixCallback', this);
     let room = Game.rooms[roomName];
     let costMatrix = new PathFinder.CostMatrix();
     // Previous Source Keeper where also excluded?
@@ -324,36 +311,6 @@ Room.prototype.getMatrixCallback = function(end) {
         }
       }
     }
-
-    // Ignore walls?
-    //    let structures = room.find(FIND_STRUCTURES, {
-    //      filter: function(object) {
-    //        if (object.structureType == STRUCTURE_ROAD) {
-    //          return false;
-    //        }
-    //        if (object.structureType == STRUCTURE_RAMPART) {
-    //          return !object.my;
-    //        }
-    //        return true;
-    //      }
-    //    });
-    //    for (let structure of structures) {
-    //      costMatrix.set(structure.pos.x, structure.pos.y, 0xFF);
-    //    }
-    //    let constructionSites = room.find(FIND_CONSTRUCTION_SITES, {
-    //      filter: function(object) {
-    //        if (object.structureType == STRUCTURE_ROAD) {
-    //          return false;
-    //        }
-    //        if (object.structureType == STRUCTURE_RAMPART) {
-    //          return object.my;
-    //        }
-    //        return true;
-    //      }
-    //    });
-    //    for (let constructionSite of constructionSites) {
-    //      costMatrix.set(constructionSite.pos.x, constructionSite.pos.y, 0xFF);
-    //    }
     return costMatrix;
   };
 

--- a/src/prototype_room_wallsetter.js
+++ b/src/prototype_room_wallsetter.js
@@ -43,12 +43,12 @@ Room.prototype.checkExitsAreReachable = function() {
     }
     return false;
   };
-  let costMatrixBase = PathFinder.CostMatrix.deserialize(this.memory.costMatrix.base);
+  let costMatrixBase = this.getMemoryCostMatrix();
 
   let exits = this.find(FIND_EXIT);
   let room = this;
   var callbackNew = function(roomName) {
-    let costMatrix = PathFinder.CostMatrix.deserialize(room.memory.costMatrix.base);
+    let costMatrix = room.getMemoryCostMatrix();
     return costMatrix;
   };
   for (let exit of exits) {
@@ -79,7 +79,7 @@ Room.prototype.checkExitsAreReachable = function() {
         if (inLayer(this, pathPos)) {
           this.memory.walls.ramparts.push(pathPos);
           costMatrixBase.set(pathPos.x, pathPos.y, 0);
-          this.memory.costMatrix.base = costMatrixBase.serialize();
+          this.setMemoryCostMatrix(costMatrixBase);
         }
       }
     }
@@ -221,7 +221,7 @@ Room.prototype.closeExitsByPath = function() {
       this.log('pathPos: ' + pathPos);
 
       var structure = STRUCTURE_WALL;
-      let costMatrixBase = PathFinder.CostMatrix.deserialize(this.memory.costMatrix.base);
+      let costMatrixBase = this.getMemoryCostMatrix();
       if (pathPos.inPath() || pathPos.inPositions()) {
         structure = STRUCTURE_RAMPART;
         costMatrixBase.set(pathPos.x, pathPos.y, 0);
@@ -229,7 +229,7 @@ Room.prototype.closeExitsByPath = function() {
       } else {
         costMatrixBase.set(pathPos.x, pathPos.y, 0xff);
       }
-      this.memory.costMatrix.base = costMatrixBase.serialize();
+      this.setMemoryCostMatrix(costMatrixBase);
       this.memory.walls.layer[this.memory.walls.layer_i].push(pathPos);
       var returnCode = pathPos.createConstructionSite(structure);
       if (returnCode == ERR_FULL) {

--- a/src/role_defendmelee.js
+++ b/src/role_defendmelee.js
@@ -29,7 +29,7 @@ roles.defendmelee.execute = function(creep) {
   let search = PathFinder.search(
     creep.pos,
     hostile.pos, {
-      roomCallback: creep.room.getAvoids(creep.room)
+      roomCallback: creep.room.getCostMatrixCallback(hostile.pos)
     });
   let direction = creep.pos.getDirectionTo(search.path[0]);
   creep.moveCreep(search.path[0], (direction + 3) % 8 + 1);

--- a/src/role_powertransporter.js
+++ b/src/role_powertransporter.js
@@ -30,10 +30,7 @@ roles.powertransporter.action = function(creep) {
 
   if (creep.memory.reverse && creep.inBase()) {
     creep.log('Fill storage');
-    creep.moveTo(creep.room.storage, {
-      ignoreCreeps: true,
-      costCallback: creep.room.getAvoids(creep.room)
-    });
+    creep.moveToMy(creep.room.storage);
     var return_code = creep.transfer(creep.room.storage, RESOURCE_POWER);
     if (return_code == OK) {
       creep.memory.target = creep.memory.old_target;

--- a/src/role_scout.js
+++ b/src/role_scout.js
@@ -93,10 +93,7 @@ roles.scout.execute = function(creep) {
           pos: targetPosObject,
           range: 20
         }, {
-          roomCallback: creep.room.getAvoids(creep.room, {
-            pos: targetPosObject,
-            scout: true
-          })
+          roomCallback: creep.room.getCostMatrixCallback(targetPosObject)
         }
       );
     } catch (e) {

--- a/src/role_scoutnextroom.js
+++ b/src/role_scoutnextroom.js
@@ -177,10 +177,7 @@ roles.scoutnextroom.execute = function(creep) {
       range: 1
     }, {
       // TODO Can prevent the creep move through the room (base: W1N7, room: W2N7, private server)
-      roomCallback: creep.room.getAvoids(creep.room, {
-        //        pos: targetPosObject,
-        scout: true
-      }),
+      roomCallback: creep.room.getCostMatrixCallback(targetPosObject, true),
       maxRooms: 1
     }
   );

--- a/src/role_squadheal.js
+++ b/src/role_squadheal.js
@@ -96,7 +96,7 @@ roles.squadheal.action = function(creep) {
         pos: exit,
         range: 0
       }, {
-        roomCallback: creep.room.getAvoids(creep.room, {}, true),
+        roomCallback: creep.room.getCostMatrixCallback(exit),
         maxRooms: 1
       }
     );


### PR DESCRIPTION
## Introduce moveToMy
Combine usual `PathFinder.search` and
`moveTo(target, {callback: getAvoids()})` in
`creep.moveToMy(target, range)`.

## Introduce cache / memory methods for costMatrix
CostMatrixes are stored in plain format in the cache.
CostMatrixes of controlled rooms are stored in `Memory` serialized.