### PR TITLE
Creep Mineral Hotfix

### DIFF
--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -449,6 +449,23 @@ Creep.prototype.handleMineralCreep = function() {
         if (lab0.cooldown === 0) {
           lab0.runReaction(lab1, lab2);
         }
+
+      }
+      if (lab0.mineralAmount > 1000) {
+        creep.room.memory.fullLab = 1;
+      }
+
+      if (lab0.mineralAmount < 100) {
+        creep.room.memory.fullLab = 0;
+      }
+    }
+
+    if (creep.room.memory.fullLab === 1) {
+      if (_.sum(creep.carry) > 0) {
+        creep.memory.state = 0;
+      }
+      if (_.sum(creep.carry) === 0) {
+        creep.memory.state = 8;
       }
     }
 


### PR DESCRIPTION
Monitor reaction product lab for target amount of minerals.
At target amount, pull minerals out of terminal.