### PR TITLE
Remove moveTo(25,25) in nextroomer execute

### DIFF
--- a/src/role_nextroomer.js
+++ b/src/role_nextroomer.js
@@ -349,5 +349,5 @@ roles.nextroomer.action = function(creep) {
 
 roles.nextroomer.execute = function(creep) {
   creep.log('Execute!!!');
-  creep.moveTo(25, 25);
+  //creep.moveTo(25, 25);
 };


### PR DESCRIPTION
Not sure why execute gets called, but this fixes them getting stuck after execute and eop message.