### PR TITLE
Fix: Invalid findPropertyFiltre filter

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -186,7 +186,7 @@ Creep.prototype.buildRoad = function() {
     return true;
   }
 
-  constructionSites = this.room.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD]);
+  constructionSites = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD]);
   if (constructionSites.length <= config.buildRoad.maxConstructionSitesRoom && Object.keys(Game.constructionSites).length < config.buildRoad.maxConstructionSitesTotal && this.pos.inPath()) {
     let returnCode = this.pos.createConstructionSite(STRUCTURE_ROAD);
     if (returnCode === OK) {

--- a/src/prototype_creep_fight.js
+++ b/src/prototype_creep_fight.js
@@ -309,7 +309,7 @@ Creep.prototype.fightRanged = function(target) {
       costMatrix.set(49, i, 0xFF);
     }
     let room = Game.rooms[roomName];
-    let structures = room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_ROAD], true);
+    let structures = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_ROAD], true);
     for (let i in structures) {
       let structure = structures[i];
       costMatrix.set(structure.pos.x, structure.pos.y, 0xFF);

--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -399,7 +399,7 @@ Creep.prototype.handleMineralCreep = function() {
 
   function checkNuke(creep) {
     if (creep.room.terminal.store[RESOURCE_GHODIUM] > 500 || creep.carry[RESOURCE_GHODIUM]) {
-      let nukers = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_NUKER]);
+      let nukers = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_NUKER]);
       if (nukers.length > 0) {
         let nuker = nukers[0];
         if (nuker.ghodium < nuker.ghodiumCapacity) {

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -10,7 +10,7 @@ Creep.prototype.harvesterBeforeStorage = function() {
   }
 
   methods.push(Creep.transferEnergy);
-  let structures = this.room.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_CONTROLLER], true);
+  let structures = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_CONTROLLER], true);
   if (structures.length > 0) {
     methods.push(Creep.constructTask);
   }
@@ -616,7 +616,7 @@ Creep.prototype.construct = function() {
       for (let structureId in structures) {
         let structure = structures[structureId];
         if (structure.structureType === STRUCTURE_SPAWN) {
-          let spawns = this.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+          let spawns = this.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
           if (spawns.length <= 1) {
             target.remove();
             return true;
@@ -640,7 +640,7 @@ Creep.prototype.construct = function() {
           costMatrix.set(creep.pos.x, creep.pos.y, 0);
 
           // TODO excluding structures, for the case where the spawn is in the wrong spot (I guess this can be handled better)
-          let structures = room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+          let structures = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
           for (let structure of structures) {
             costMatrix.set(structure.pos.x, structure.pos.y, config.layout.structureAvoid);
           }
@@ -796,7 +796,7 @@ Creep.prototype.handleReserver = function() {
       if (structurers.length > 0) {
         return false;
       }
-      var resource_structures = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+      var resource_structures = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
       if (resource_structures.length > 0 && !creep.room.controller.my) {
         creep.log('Call structurer from ' + creep.memory.base + ' because of ' + resource_structures[0].structureType);
         Game.rooms[creep.memory.base].checkRoleToSpawn('structurer', 1, undefined, creep.room.name);

--- a/src/prototype_creep_routing.js
+++ b/src/prototype_creep_routing.js
@@ -246,7 +246,7 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, skipPreM
           let costMatrix = PathFinder.CostMatrix.deserialize(room.memory.costMatrix.base);
 
           // TODO excluding structures, for the case where the spawn is in the wrong spot (I guess this can be handled better)
-          let structures = room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+          let structures = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
           for (let structure of structures) {
             costMatrix.set(structure.pos.x, structure.pos.y, config.layout.structureAvoid);
           }

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -128,7 +128,7 @@ Creep.prototype.getEnergyFromHostileStructures = function() {
   if (this.carry.energy) {
     return false;
   }
-  let hostileStructures = this.room.findPropertyFiltre(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_RAMPART, STRUCTURE_EXTRACTOR]);
+  let hostileStructures = this.room.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_RAMPART, STRUCTURE_EXTRACTOR]);
   if (!hostileStructures.length) {
     return false;
   }
@@ -285,7 +285,7 @@ Creep.prototype.repairStructure = function() {
 
   let nukes = this.room.find(FIND_NUKES);
   if (nukes.length > 0) {
-    let spawns = this.room.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+    let spawns = this.room.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
     if (spawns.length > 0) {
       for (let spawn of spawns) {
         let found = false;

--- a/src/prototype_room_basebuilder.js
+++ b/src/prototype_room_basebuilder.js
@@ -61,7 +61,7 @@ Room.prototype.destroyStructure = function(structure) {
   if (posIsIn(structure.pos, this.memory.position.structure[structure.structureType])) {
     return false;
   }
-  let structures = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [structure.structureType]);
+  let structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [structure.structureType]);
   let structuresMin = 0;
   if (structure.structureType === STRUCTURE_SPAWN) {
     structuresMin = 1;
@@ -99,7 +99,7 @@ Room.prototype.destroyStructure = function(structure) {
     // Build ramparts around the spawn if wallThickness > 1
     if (config.layout.wallThickness > 1) {
       let costMatrixBase = PathFinder.CostMatrix.deserialize(this.memory.costMatrix.base);
-      let spawns = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+      let spawns = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
       let getWalls = function(object) {
         return object.structureType === STRUCTURE_WALL;
       };
@@ -174,7 +174,7 @@ Room.prototype.checkWrongStructure = function() {
   //  this.log('checkWrongStructure: controller.level < 6');
   //  return false;
   //}
-  let structures = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
+  let structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
   for (let structure of structures) {
     if (this.destroyStructure(structure)) {
       return true;
@@ -206,8 +206,8 @@ Room.prototype.clearPosition = function(pos, structure) {
 };
 
 Room.prototype.setupStructure = function(structure) {
-  var structures = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [structure]);
-  var constructionsites = this.findPropertyFiltre(FIND_CONSTRUCTION_SITES, 'structureType', [structure]);
+  var structures = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [structure]);
+  var constructionsites = this.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [structure]);
   // Only build one spawn at a time, especially for reviving
   if (structure === STRUCTURE_SPAWN) {
     if (constructionsites.length > 0) {
@@ -291,7 +291,7 @@ Room.prototype.buildStructures = function() {
     return false;
   }
 
-  let constructionSites = this.findPropertyFiltre(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], true);
+  let constructionSites = this.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], true);
   if (constructionSites.length > 3) {
     //    this.log('basebuilder.setup: Too many construction sites');
     return true;
@@ -316,7 +316,7 @@ Room.prototype.buildStructures = function() {
     return true;
   }
 
-  if (!this.storage || this.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_LINK]).length > 0) {
+  if (!this.storage || this.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_LINK]).length > 0) {
     return false;
   }
   if (this.setupStructure(STRUCTURE_POWER_SPAWN)) {

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -47,7 +47,7 @@ Room.prototype.getAvoids = function(target, inRoom) {
       if (target && target.pos) {
         costMatrix.set(target.pos.x, target.pos.y, 0);
       }
-      let structures = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD], true);
+      let structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD], true);
       for (let structure of structures) {
         costMatrix.set(structure.pos.x, structure.pos.y, 255);
       }

--- a/src/prototype_room_defense.js
+++ b/src/prototype_room_defense.js
@@ -90,7 +90,7 @@ Room.prototype.handleNukeAttack = function() {
 
 Room.prototype.handleTower = function() {
   var tower_id;
-  var towers = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_TOWER]);
+  var towers = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_TOWER]);
   if (towers.length === 0) {
     return false;
   }

--- a/src/prototype_room_external.js
+++ b/src/prototype_room_external.js
@@ -88,7 +88,7 @@ Room.prototype.externalHandleHighwayRoom = function() {
     return false;
   }
 
-  var structures = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
+  var structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
   if (structures.length === 0) {
     if (Memory.powerBanks) {
       delete Memory.powerBanks[this.name];
@@ -197,7 +197,7 @@ Room.prototype.handleOccupiedRoom = function() {
       if (myCreeps.length > 0) {
         return false;
       }
-      var spawns = this.findPropertyFiltre(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+      var spawns = this.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
       if (spawns.length > 0) {
         this.attackRoom();
       }

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -102,7 +102,7 @@ Room.prototype.handleLinks = function() {
 };
 
 Room.prototype.handlePowerSpawn = function() {
-  let powerSpawns = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_POWER_SPAWN]);
+  let powerSpawns = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_POWER_SPAWN]);
   if (powerSpawns.length === 0) {
     return false;
   }
@@ -120,7 +120,7 @@ Room.prototype.handleObserver = function() {
   if (CONTROLLER_STRUCTURES.observer[this.controller.level] === 0) {
     return false;
   }
-  let observers = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_OBSERVER]);
+  let observers = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_OBSERVER]);
   if (observers.length > 0) {
     if (!this.memory.observe_rooms) {
       // TODO manage switch from E to W and S to N
@@ -269,7 +269,7 @@ Room.prototype.executeRoom = function() {
   let cpuUsed = Game.cpu.getUsed();
   this.buildBase();
   this.memory.attackTimer = this.memory.attackTimer || 0;
-  var spawns = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+  var spawns = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
   var hostiles = this.find(FIND_HOSTILE_CREEPS, {
     filter: this.findAttackCreeps
   });
@@ -330,7 +330,7 @@ Room.prototype.executeRoom = function() {
     }
   }
   if (this.memory.attackTimer >= 50 && this.controller.level > 6) {
-    let towers = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_TOWER]);
+    let towers = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_TOWER]);
     if (towers.length === 0) {
       this.memory.attackTimer = 47;
     } else {
@@ -391,7 +391,7 @@ Room.prototype.executeRoom = function() {
     this.checkRoleToSpawn('upgrader', 1, this.controller.id);
   }
 
-  var constructionSites = this.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD, STRUCTURE_WALL, STRUCTURE_RAMPART], true);
+  var constructionSites = this.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD, STRUCTURE_WALL, STRUCTURE_RAMPART], true);
   if (constructionSites.length > 0) {
     let amount = 1;
     for (let cs of constructionSites) {
@@ -403,7 +403,7 @@ Room.prototype.executeRoom = function() {
   } else if (this.memory.misplacedSpawn && this.storage && this.storage.store.energy > 20000 && this.energyAvailable >= this.energyCapacityAvailable - 300) {
     this.checkRoleToSpawn('planer', 4);
   }
-  let extractors = this.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_EXTRACTOR]);
+  let extractors = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_EXTRACTOR]);
   if (this.terminal && extractors.length > 0) {
     let minerals = this.find(FIND_MINERALS);
     if (minerals.length > 0 && minerals[0].mineralAmount > 0) {
@@ -420,7 +420,7 @@ Room.prototype.executeRoom = function() {
   if (!building && nextroomers.length === 0) {
     this.handleScout();
   }
-  let constructionSitesBlocker = this.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL]);
+  let constructionSitesBlocker = this.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL]);
   this.handleTower();
   if (this.controller.level > 1 && this.memory.walls && this.memory.walls.finished) {
     this.checkRoleToSpawn('repairer');

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -34,7 +34,7 @@ Room.prototype.findPropertyFiltre = function(findTarget, property, properties, w
   let table = {};
   _.each(properties, e => table[e] = true);
   return this.find(findTarget, {
-    filter: s => (!without && table[s[property]]) || !table[s[property]]
+    filter: s => without ? !table[s[property]] : table[s[property]]
   });
 };
 

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -30,7 +30,7 @@ Room.prototype.nearestRoomName = function(roomsNames, limit) {
  * @param  {Boolean} [without=false] Exclude or include the properties to find.
  * @return {Array}                  the objects returned in an array.
  */
-Room.prototype.findPropertyFiltre = function(findTarget, property, properties, without = false) {
+Room.prototype.findPropertyFilter = function(findTarget, property, properties, without = false) {
   let table = {};
   _.each(properties, e => table[e] = true);
   return this.find(findTarget, {

--- a/src/prototype_room_wallsetter.js
+++ b/src/prototype_room_wallsetter.js
@@ -3,7 +3,7 @@
 Room.prototype.buildBlockers = function() {
   //   this.log('buildBlockers: ' + this.memory.controllerLevel.buildBlockersInterval);
 
-  var spawns = this.findPropertyFiltre(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+  var spawns = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
   if (spawns.length === 0) {
     return false;
   }

--- a/src/role_nextroomer.js
+++ b/src/role_nextroomer.js
@@ -228,7 +228,7 @@ roles.nextroomer.settle = function(creep) {
   }
 
   if (_.sum(creep.carry) === 0) {
-    let hostileStructures = creep.room.findPropertyFiltre(FIND_HOSTILE_STRUCTURES, 'structureType',
+    let hostileStructures = creep.room.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType',
       [STRUCTURE_RAMPART, STRUCTURE_EXTRACTOR, STRUCTURE_WALL, STRUCTURE_CONTROLLER]);
     if (hostileStructures.length) {
       let structure = _.max(hostileStructures, s => s.structureType === STRUCTURE_STORAGE);
@@ -251,7 +251,7 @@ roles.nextroomer.settle = function(creep) {
   }
 
   if (creep.room.energyCapacityAvailable < 300) {
-    let constructionSites = creep.room.findPropertyFiltre(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_LAB, STRUCTURE_NUKER, STRUCTURE_TERMINAL]);
+    let constructionSites = creep.room.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_LAB, STRUCTURE_NUKER, STRUCTURE_TERMINAL]);
     for (let cs of constructionSites) {
       cs.remove();
     }
@@ -261,7 +261,7 @@ roles.nextroomer.settle = function(creep) {
   if (creep.room.controller.ticksToDowngrade < 1500) {
     methods.push(Creep.upgradeControllerTask);
   }
-  let structures = creep.room.findPropertyFiltre(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
+  let structures = creep.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
   if (creep.room.controller.level >= 3 && structures.length > 0) {
     methods.push(Creep.constructTask);
   }

--- a/src/role_powerattacker.js
+++ b/src/role_powerattacker.js
@@ -42,7 +42,7 @@ roles.powerattacker.action = function(creep) {
     }
   }
 
-  var power_bank = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
+  var power_bank = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
 
   if (power_bank.length === 0) {
     if (hostileCreep !== null) {

--- a/src/role_powerdefender.js
+++ b/src/role_powerdefender.js
@@ -23,7 +23,7 @@ roles.powerdefender.action = function(creep) {
     creep.rangedAttack(hostileCreeps[0]);
     return true;
   }
-  var powerBank = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
+  var powerBank = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
   if (powerBank.length === 0) {
     let hostileCreep = creep.findClosestEnemy();
     if (hostileCreep !== null) {

--- a/src/role_powerhealer.js
+++ b/src/role_powerhealer.js
@@ -40,7 +40,7 @@ roles.powerhealer.action = function(creep) {
         return object.hits < object.hitsMax / 1.5;
       }
     });
-    var power_bank = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
+    var power_bank = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
     if (power_bank.length > 0 && power_bank[0].hits > 100000) {
       creep.spawnReplacement();
     }

--- a/src/role_powertransporter.js
+++ b/src/role_powertransporter.js
@@ -43,7 +43,7 @@ roles.powertransporter.action = function(creep) {
       creep.moveTo(nextExit);
       return true;
     }
-    var power_bank = creep.room.findPropertyFiltre(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
+    var power_bank = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_POWER_BANK]);
     if (power_bank.length > 0) {
       var range = creep.pos.getRangeTo(power_bank[0]);
       if (range > 3) {


### PR DESCRIPTION
When without was false and table[s[property]] was false it was always returning true, instead of the intended false.