### PR TITLE
Handle Stuck &&  Harvester Fill Misplaced Spawn for RCL 4

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -84,7 +84,7 @@ Creep.prototype.handle = function() {
     if (this.memory.last === undefined) {
       this.memory.last = {};
     }
-    if(this.fatigue === 0){
+    if (this.fatigue === 0){
       let last = this.memory.last;
       this.memory.last = {
         pos1: this.pos,
@@ -98,17 +98,17 @@ Creep.prototype.handle = function() {
   }
 };
 Creep.prototype.isStuck = function() {
-  if(this.memory.last !== undefined && this.memory.last.pos5 !== undefined && this.pos.isEqualTo(this.memory.last.pos5.x, this.memory.last.pos5.y)){
-    if(!this.memory.stuckCount){
+  if (this.memory.last !== undefined && this.memory.last.pos5 !== undefined && this.pos.isEqualTo(this.memory.last.pos5.x, this.memory.last.pos5.y)) {
+    if (!this.memory.stuckCount) {
       this.memory.stuckCount = 0;
     }
-    if(!this.memory.stuckx){
+    if (!this.memory.stuckx) {
       this.memory.stuckx = this.memory.last.pos1.x;
     }
-    if(!this.memory.stucky){
+    if (!this.memory.stucky) {
       this.memory.stucky = this.memory.last.pos1.y;
     }
-    if(this.memory.stuckx == this.memory.last.pos1.x && this.memory.stucky == this.memory.last.pos1.y){
+    if (this.memory.stuckx == this.memory.last.pos1.x && this.memory.stucky == this.memory.last.pos1.y) {
       return true;
     } else {
       return false;
@@ -118,10 +118,10 @@ Creep.prototype.isStuck = function() {
   }
 };
 Creep.prototype.handleStuck = function() {
-  if(this.isStuck() && (this.role == 'harvester' || this.role == 'carry' || this.role == 'planer' || this.role == 'repairer' || this.role == 'scout')){
+  if (this.isStuck() && (this.role == 'harvester' || this.role == 'carry' || this.role == 'planer' || this.role == 'repairer' || this.role == 'scout')) {
     this.memory.stuckCount = this.memory.stuckCount + 1;
     this.log('Stuck! - ' + this.memory.stuckCount);
-    if(this.memory.stuckCount > 100){
+    if (this.memory.stuckCount > 100) {
       this.log('UnStuck!');
       this.suicide();
     }

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -84,7 +84,7 @@ Creep.prototype.handle = function() {
     if (this.memory.last === undefined) {
       this.memory.last = {};
     }
-    if (this.fatigue === 0){
+    if (this.fatigue === 0) {
       let last = this.memory.last;
       this.memory.last = {
         pos1: this.pos,

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -92,13 +92,38 @@ Creep.prototype.handle = function() {
     };
   }
 };
-
 Creep.prototype.isStuck = function() {
-  return this.memory.last !== undefined &&
-    this.memory.last.pos3 !== undefined &&
-    this.pos.isEqualTo(this.memory.last.pos3.x, this.memory.last.pos3.y);
+  if(this.memory.last !== undefined && this.memory.last.pos3 !== undefined && this.pos.isEqualTo(this.memory.last.pos3.x, this.memory.last.pos3.y)){
+    if(!this.memory.stuckCount){
+      this.memory.stuckCount = 0;
+    }  if(!this.memory.stuckx){
+      this.memory.stuckx = this.memory.last.pos1.x;
+    }
+    if(!this.memory.stucky){
+      this.memory.stucky = this.memory.last.pos1.y;
+    }
+    if(this.memory.stuckx == this.memory.last.pos1.x && this.memory.stucky == this.memory.last.pos1.y){
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  };
 };
-
+Creep.prototype.handleStuck = function() {
+  if(this.isStuck() && (this.role == 'harvester' || this.role == 'carry' || this.role == 'planer' || this.role == 'repairer' || this.role == 'scout')){
+    this.memory.stuckCount = this.memory.stuckCount + 1;
+    this.log('Stuck! - ' + this.memory.stuckCount);
+    if(this.memory.stuckCount > 100){
+      this.log('UnStuck!')
+      this.suicide();
+    }
+    return true;
+  } else {
+    this.memory.stuckCount = 0;
+    return false; };
+};
 Creep.prototype.getEnergyFromStructure = function() {
   if (this.carry.energy === this.carryCapacity) {
     return false;

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -84,16 +84,20 @@ Creep.prototype.handle = function() {
     if (this.memory.last === undefined) {
       this.memory.last = {};
     }
-    let last = this.memory.last;
-    this.memory.last = {
-      pos1: this.pos,
-      pos2: last.pos1,
-      pos3: last.pos2,
-    };
+    if(this.fatigue === 0){
+      let last = this.memory.last;
+      this.memory.last = {
+        pos1: this.pos,
+        pos2: last.pos1,
+        pos3: last.pos2,
+        pos4: last.pos3,
+        pos5: last.pos4,
+      };
+    }
+    this.handleStuck();
   }
-};
 Creep.prototype.isStuck = function() {
-  if(this.memory.last !== undefined && this.memory.last.pos3 !== undefined && this.pos.isEqualTo(this.memory.last.pos3.x, this.memory.last.pos3.y)){
+  if(this.memory.last !== undefined && this.memory.last.pos5 !== undefined && this.pos.isEqualTo(this.memory.last.pos5.x, this.memory.last.pos5.y)){
     if(!this.memory.stuckCount){
       this.memory.stuckCount = 0;
     }  if(!this.memory.stuckx){

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -115,21 +115,21 @@ Creep.prototype.isStuck = function() {
     }
   } else {
     return false;
-  };
+  }
 };
 Creep.prototype.handleStuck = function() {
   if(this.isStuck() && (this.role == 'harvester' || this.role == 'carry' || this.role == 'planer' || this.role == 'repairer' || this.role == 'scout')){
     this.memory.stuckCount = this.memory.stuckCount + 1;
     this.log('Stuck! - ' + this.memory.stuckCount);
     if(this.memory.stuckCount > 100){
-      this.log('UnStuck!')
+      this.log('UnStuck!');
       this.suicide();
     }
     return true;
   } else {
     this.memory.stuckCount = 0;
     return false;
-  };
+  }
 };
 Creep.prototype.getEnergyFromStructure = function() {
   if (this.carry.energy === this.carryCapacity) {

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -96,6 +96,7 @@ Creep.prototype.handle = function() {
     }
     this.handleStuck();
   }
+};
 Creep.prototype.isStuck = function() {
   if(this.memory.last !== undefined && this.memory.last.pos5 !== undefined && this.pos.isEqualTo(this.memory.last.pos5.x, this.memory.last.pos5.y)){
     if(!this.memory.stuckCount){

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -108,7 +108,7 @@ Creep.prototype.isStuck = function() {
     if (!this.memory.stucky) {
       this.memory.stucky = this.memory.last.pos1.y;
     }
-    if (this.memory.stuckx == this.memory.last.pos1.x && this.memory.stucky == this.memory.last.pos1.y) {
+    if (this.memory.stuckx === this.memory.last.pos1.x && this.memory.stucky === this.memory.last.pos1.y) {
       return true;
     } else {
       return false;
@@ -118,7 +118,7 @@ Creep.prototype.isStuck = function() {
   }
 };
 Creep.prototype.handleStuck = function() {
-  if (this.isStuck() && (this.role == 'harvester' || this.role == 'carry' || this.role == 'planer' || this.role == 'repairer' || this.role == 'scout')) {
+  if (this.isStuck() && (this.role === 'harvester' || this.role === 'carry' || this.role === 'planer' || this.role === 'repairer' || this.role === 'scout')) {
     this.memory.stuckCount = this.memory.stuckCount + 1;
     this.log('Stuck! - ' + this.memory.stuckCount);
     if (this.memory.stuckCount > 100) {

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -101,7 +101,8 @@ Creep.prototype.isStuck = function() {
   if(this.memory.last !== undefined && this.memory.last.pos5 !== undefined && this.pos.isEqualTo(this.memory.last.pos5.x, this.memory.last.pos5.y)){
     if(!this.memory.stuckCount){
       this.memory.stuckCount = 0;
-    }  if(!this.memory.stuckx){
+    }
+    if(!this.memory.stuckx){
       this.memory.stuckx = this.memory.last.pos1.x;
     }
     if(!this.memory.stucky){
@@ -127,7 +128,8 @@ Creep.prototype.handleStuck = function() {
     return true;
   } else {
     this.memory.stuckCount = 0;
-    return false; };
+    return false;
+  };
 };
 Creep.prototype.getEnergyFromStructure = function() {
   if (this.carry.energy === this.carryCapacity) {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -432,7 +432,7 @@ Room.prototype.executeRoom = function() {
   this.handleTerminal();
   this.handleNukeAttack();
 
-  if(!this.memory.spawnTimer){
+  if(!this.memory.spawnTimer) {
     this.memory.spawnTimer = 0;
   }
   var harvesters = this.find(FIND_MY_CREEPS, {
@@ -443,10 +443,10 @@ Room.prototype.executeRoom = function() {
       return false;
     }
   });
-  if(harvesters.length < 1){
+  if (harvesters.length < 1) {
     this.spawnCheckForCreate();
   }
-  if(this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0 ) || this.memory.attackTimer > 15){
+  if (this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
     this.memory.spawnTimer = 0;
     this.spawnCheckForCreate();
   } else {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -432,7 +432,7 @@ Room.prototype.executeRoom = function() {
   this.handleTerminal();
   this.handleNukeAttack();
 
-  if(!this.memory.spawnTimer) {
+  if (!this.memory.spawnTimer) {
     this.memory.spawnTimer = 0;
   }
   var harvesters = this.find(FIND_MY_CREEPS, {
@@ -446,7 +446,7 @@ Room.prototype.executeRoom = function() {
   if (harvesters.length < 1) {
     this.spawnCheckForCreate();
   }
-  if (this.memory.spawnTimer > 100 || this.energyAvailable === this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
+  if (this.memory.spawnTimer > 100 || this.energyAvailable === this.energyCapacityAvailable || (this.controller.level * 250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
     this.memory.spawnTimer = 0;
     this.spawnCheckForCreate();
   } else {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -438,7 +438,7 @@ Room.prototype.executeRoom = function() {
   var harvesters = this.find(FIND_MY_CREEPS, {
     filter: function(object) {
       if (object.memory.role === 'harvester') {
-        return object.memory.base == room.name;
+        return object.memory.base === room.name;
       }
       return false;
     }
@@ -446,7 +446,7 @@ Room.prototype.executeRoom = function() {
   if (harvesters.length < 1) {
     this.spawnCheckForCreate();
   }
-  if (this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
+  if (this.memory.spawnTimer > 100 || this.energyAvailable === this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
     this.memory.spawnTimer = 0;
     this.spawnCheckForCreate();
   } else {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -432,10 +432,26 @@ Room.prototype.executeRoom = function() {
   this.handleTerminal();
   this.handleNukeAttack();
 
-  if (Game.time % 10 === 0) {
+  if(!this.memory.spawnTimer){
+    this.memory.spawnTimer = 0;
+  }
+  var harvesters = this.find(FIND_MY_CREEPS, {
+    filter: function(object) {
+      if (object.memory.role === 'harvester') {
+        return object.memory.base == room.name;
+      }
+      return false;
+    }
+  });
+  if(harvesters.length < 1){
     this.spawnCheckForCreate();
   }
-
+  if(this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 == 0 ) || this.memory.attackTimer > 15){
+    this.memory.spawnTimer = 0;
+    this.spawnCheckForCreate();
+  } else {
+    this.memory.spawnTimer = this.memory.spawnTimer + 1;
+  }
   this.handleMarket();
   brain.stats.addRoom(this.name, cpuUsed);
   return true;

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -431,27 +431,10 @@ Room.prototype.executeRoom = function() {
   this.handlePowerSpawn();
   this.handleTerminal();
   this.handleNukeAttack();
+  if (Game.time % 50 === 0) {
+    this.spawnCheckForCreate();
+  }
 
-  if (!this.memory.spawnTimer) {
-    this.memory.spawnTimer = 0;
-  }
-  var harvesters = this.find(FIND_MY_CREEPS, {
-    filter: function(object) {
-      if (object.memory.role === 'harvester') {
-        return object.memory.base === room.name;
-      }
-      return false;
-    }
-  });
-  if (harvesters.length < 1) {
-    this.spawnCheckForCreate();
-  }
-  if (this.memory.spawnTimer > 100 || this.energyAvailable === this.energyCapacityAvailable || (this.controller.level * 250 < this.energyCapacityAvailable && Game.Time % 50 === 0) || this.memory.attackTimer > 15) {
-    this.memory.spawnTimer = 0;
-    this.spawnCheckForCreate();
-  } else {
-    this.memory.spawnTimer = this.memory.spawnTimer + 1;
-  }
   this.handleMarket();
   brain.stats.addRoom(this.name, cpuUsed);
   return true;

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -446,7 +446,7 @@ Room.prototype.executeRoom = function() {
   if(harvesters.length < 1){
     this.spawnCheckForCreate();
   }
-  if(this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 == 0 ) || this.memory.attackTimer > 15){
+  if(this.memory.spawnTimer > 100 ||  this.energyAvailable == this.energyCapacityAvailable || (this.controller.level *250 < this.energyCapacityAvailable && Game.Time % 50 === 0 ) || this.memory.attackTimer > 15){
     this.memory.spawnTimer = 0;
     this.spawnCheckForCreate();
   } else {

--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -53,7 +53,7 @@ roles.harvester.preMove = function(creep, directions) {
   creep.setNextSpawn();
   creep.spawnReplacement(1);
 
-  if (!creep.room.storage || creep.room.memory.misplacedSpawn ||(creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
+  if (!creep.room.storage || creep.room.memory.misplacedSpawn || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
     creep.harvesterBeforeStorage();
     creep.memory.routing.reached = true;
     return true;

--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -53,7 +53,7 @@ roles.harvester.preMove = function(creep, directions) {
   creep.setNextSpawn();
   creep.spawnReplacement(1);
 
-  if (!creep.room.storage || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
+  if (!creep.room.storage || creep.room.memory.misplacedSpawn ||(creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
     creep.harvesterBeforeStorage();
     creep.memory.routing.reached = true;
     return true;


### PR DESCRIPTION
This has 4 items in it -
1. isStuck updated to store last stuck position - also tracks 5 positions instead of 3.

2. Handle Stuck for Carry, Harvester, Planer & repairer & scout.  They should move every tick, if they have not moved for 105 ticks something is really wrong.

3. Harvester filling spawn when the spawn is misplaced (not on path) at RCL 4
