### PR TITLE
Improve logic on sourcer overflow. 

### DIFF
--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -89,8 +89,8 @@ Creep.prototype.pickupWhileMoving = function(reverse) {
 
     if (resources.length > 0) {
       let resource = Game.getObjectById(resources[0].id);
-      this.pickup(resource);
-      return _.sum(this.carry) + resource.amount > 0.5 * this.carryCapacity;
+      const amount = this.pickupOrWithdrawFromSourcer(resource);
+      return _.sum(this.carry) + amount > 0.5 * this.carryCapacity;
     }
 
     if (this.room.name === this.memory.routing.targetRoom) {

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -336,6 +336,39 @@ Creep.prototype.repairStructure = function() {
   return false;
 };
 
+/**
+ *
+ * @param {Resource} target Resource object to pick up
+ * @return {number} total received resources amount
+ */
+Creep.prototype.pickupOrWithdrawFromSourcer = function(target) {
+  const creepFreeSpace = this.carryCapacity - _.sum(this.carry);
+  let pickedUp = 0;
+  // this.log('pickupOrWithdrawFromSourcer free '+creepFreeSpace+' '+target+' '+target.amount)
+  if (target.amount < creepFreeSpace) {
+    let container = target.pos.lookFor(LOOK_STRUCTURES).find(function(structure) {
+      return structure.structureType === STRUCTURE_CONTAINER && structure.store[target.resourceType] > 0 && _.sum(structure.store) === structure.storeCapacity;
+    });
+    if (container) {
+      const toWithdraw = Math.min(creepFreeSpace - target.amount, container.store[target.resourceType]);
+      this.withdraw(container, target.resourceType, toWithdraw);
+      pickedUp += toWithdraw;
+    } else {
+      let sourcer = target.pos.lookFor(LOOK_CREEPS).find(function(creep) {
+        return creep.memory && creep.memory.role === 'sourcer' && creep.carry[target.resourceType] > 0 && _.sum(creep.carry) === creep.carryCapacity;
+      });
+      if (sourcer) {
+        const toWithdraw = Math.min(creepFreeSpace - target.amount, sourcer.carry[target.resourceType]);
+        sourcer.transfer(this, target.resourceType, toWithdraw);
+        pickedUp += toWithdraw;
+      }
+    }
+  }
+  this.pickup(target);
+  pickedUp += target.amount;
+  return Math.min(pickedUp, creepFreeSpace);
+};
+
 Creep.prototype.getDroppedEnergy = function() {
   let target = this.pos.findClosestByRange(FIND_DROPPED_ENERGY, {
     filter: function(object) {
@@ -345,25 +378,7 @@ Creep.prototype.getDroppedEnergy = function() {
   if (target !== null) {
     let energyRange = this.pos.getRangeTo(target.pos);
     if (energyRange <= 1) {
-      const creepFreeSpace = this.carryCapacity - _.sum(this.carry);
-      if (target.amount < creepFreeSpace) {
-        let container = target.pos.lookFor(LOOK_STRUCTURES).find(function(structure) {
-          return structure.structureType === STRUCTURE_CONTAINER && structure.store.energy > 0 && _.sum(structure.store) === structure.storeCapacity;
-        });
-        if (container) {
-          const toWithdraw = Math.min(creepFreeSpace - target.amount, container.store.energy);
-          this.withdraw(container, RESOURCE_ENERGY, toWithdraw);
-        } else {
-          let sourcer = target.pos.lookFor(LOOK_CREEPS).find(function(creep) {
-            return creep.memory && creep.memory.role === 'sourcer' && creep.carry.energy > 0 && _.sum(creep.carry) === creep.carryCapacity;
-          });
-          if (sourcer) {
-            const toWithdraw = Math.min(creepFreeSpace - target.amount, sourcer.carry.energy);
-            sourcer.transfer(this, RESOURCE_ENERGY, toWithdraw);
-          }
-        }
-      }
-      this.pickup(target);
+      this.pickupOrWithdrawFromSourcer(target);
       return true;
     }
     if (target.energy > (energyRange * 10) * (this.carry.energy + 1)) {


### PR DESCRIPTION
Improve logic on sourcer overflow. Instead of waiting for dropped energy on each tick, until creep get full, withdraw than energy from sourcer/container, to get full in two ticks and free up capacity for sourcer to avoid overflowing