### PR TITLE
[WIP] Fix infinite loop of getting energy from terminal and putting it back

### DIFF
--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -116,7 +116,7 @@ Creep.prototype.handleExtractor = function() {
   if (carrying === this.carryCapacity) {
     let returnCode = this.moveToMy(this.room.terminal.pos, 1);
     for (let key in this.carry) {
-      if (this.carry[key] === 0) {
+      if (this.carry[key] === 0 || key === RESOURCE_ENERGY) {
         continue;
       }
       let returnCode = this.transfer(this.room.terminal, key);


### PR DESCRIPTION
Fix infinite loop of getting energy from terminal and putting it back. 
May be related to store.energy is exactly 50% of capacity. 
May be simulator-specific problem.
I do not test it hard enough in different enviroments, and not sure if it willn't break something else. Maybe it sould be marked as WIP until I can get enough RCL to test it in real room