### PR TITLE
Fix repairers and sometimes other creeps stack on border

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -12,7 +12,7 @@ Creep.prototype.moveToMy = function(target, range) {
       pos: target,
       range: range
     }, {
-      roomCallback: this.room.getCostMatrixCallback(target, true),
+      roomCallback: this.room.getCostMatrixCallback(target, true, this.pos.roomName === (target.pos || target).roomName),
       maxRooms: 0
     }
   );

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -6,13 +6,16 @@ Room.prototype.setCostMatrixStructures = function(costMatrix, structures, value)
   }
 };
 
-Room.prototype.getCostMatrixCallback = function(end, excludeStructures) {
+Room.prototype.getCostMatrixCallback = function(end, excludeStructures, oneRoom) {
   let costMatrix = this.getMemoryCostMatrix();
   if (!costMatrix) {
     this.updatePosition();
   }
 
   let callbackInner = (roomName) => {
+    if (oneRoom && roomName !== this.name) {
+      return false;
+    }
     let room = Game.rooms[roomName];
     if (!room) {
       return;


### PR DESCRIPTION
Sometimes creeps that should stay in room stacks on border, moving out of room and in next tick again into room, due to stayInRoom method. Most common case is repairers
The reason is due to avoidBorder, moving to target inside room costs more than move on plain terrarian (without cost matrix on adjacent room without visibility)
The fix is disallow moving into other room if source and target a both in one room.