### PR TITLE
Refactor `prototype_creep_resources`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,3 @@
-ecmaFeatures:
-  modules: true
-  jsx: true
-
 env:
   amd: true
   browser: true
@@ -57,7 +53,6 @@ rules:
   no-case-declarations: 2
   no-div-regex: 2
   no-else-return: 0
-  no-empty-label: 2
   no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2

--- a/src/config.js
+++ b/src/config.js
@@ -170,7 +170,7 @@ global.config = {
     structureAvoid: 0xFF,
     creepAvoid: 0xFF,
     wallThickness: 1,
-    version: 16,
+    version: 17,
   },
 
   mineral: {

--- a/src/config_brain_memory.js
+++ b/src/config_brain_memory.js
@@ -66,8 +66,9 @@ brain.handleUnexpectedDeadCreeps = function(name, creepMemory) {
     return;
   }
   if (unit.died) {
-    unit.died(name, creepMemory);
-    //            delete Memory.creeps[name];
+    if (unit.died(name, creepMemory)) {
+      delete Memory.creeps[name];
+    }
   } else {
     delete Memory.creeps[name];
   }

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -157,6 +157,11 @@ Creep.prototype.stayInRoom = function() {
 };
 
 Creep.prototype.buildRoad = function() {
+  // TODO make dependent on the swamp to non-swamp relation? High swamp rooms could use the roads better ...
+  if (this.room.controller && this.room.controller.level < 4) {
+    return false;
+  }
+
   // TODO as creep variable
   if (this.memory.role != 'carry' && this.memory.role != 'harvester') {
     this.getEnergyFromStructure();

--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -261,7 +261,6 @@ Creep.prototype.handleMineralCreep = function() {
 
     creep.say('A3');
 
-    //  creep.log('aa: ' + JSON.stringify(creep.memory.boostAction));
     let lab = Game.getObjectById(creep.memory.boostAction.lab);
     if (!lab) {
       return false;

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -25,18 +25,45 @@ Creep.prototype.harvesterBeforeStorage = function() {
   return true;
 };
 
+Creep.prototype.checkEnergyTransfer = function(otherCreep) {
+  // TODO duplicate from role_carry, extract to method
+  let offset = 0;
+  if (otherCreep) {
+    offset = otherCreep.carry.energy;
+  }
+
+  // define minimum carryPercentage to move back to storage
+  let carryPercentage = 0.1;
+  if (this.room.name === this.memory.routing.targetRoom) {
+    carryPercentage = config.carry.carryPercentageExtern;
+  }
+  if (this.inBase()) {
+    carryPercentage = config.carry.carryPercentageBase;
+  }
+
+  return offset + _.sum(this.carry) > carryPercentage * this.carryCapacity;
+};
+
+Creep.prototype.findCreepWhichCanTransfer = function(creeps) {
+  for (let i = 0; i < creeps.length; i++) {
+    let otherCreep = creeps[i];
+    if (!Game.creeps[otherCreep.name] || otherCreep.carry.energy < 50) {
+      continue;
+    }
+
+    if (Game.creeps[otherCreep.name].memory.role === 'carry') {
+      return this.checkEnergyTransfer(otherCreep);
+    }
+    continue;
+  }
+  return false;
+};
+
 Creep.prototype.checkForTransfer = function(direction) {
   if (!direction) {
     return false;
   }
 
-  var pos;
-  var creeps;
-  var index_calc;
-  var offset;
-  var new_path;
-
-  //  for (var direction = 1; direction < 9; direction++) {
   let adjacentPos = this.pos.getAdjacentPosition(direction);
 
   if (adjacentPos.x < 0 || adjacentPos.y < 0) {
@@ -46,31 +73,8 @@ Creep.prototype.checkForTransfer = function(direction) {
     return false;
   }
 
-  creeps = adjacentPos.lookFor('creep');
-
-  for (var name in creeps) {
-    let otherCreep = creeps[name];
-    if (!Game.creeps[otherCreep.name]) {
-      continue;
-    }
-    if (otherCreep.carry.energy < 50) {
-      continue;
-    }
-    if (Game.creeps[otherCreep.name].memory.role === 'carry') {
-      // TODO duplicate from role_carry, extract to method
-      let carryPercentage = 0.1;
-      if (this.room.name === this.memory.routing.targetRoom) {
-        carryPercentage = 0.8;
-      }
-      if (this.inBase()) {
-        carryPercentage = 0.0;
-      }
-      return otherCreep.carry.energy + _.sum(this.carry) > carryPercentage * this.carryCapacity;
-    }
-    continue;
-  }
-  //  }
-  return false;
+  let creeps = adjacentPos.lookFor('creep');
+  return this.findCreepWhichCanTransfer(creeps);
 };
 
 Creep.prototype.pickupWhileMoving = function(reverse) {
@@ -78,30 +82,27 @@ Creep.prototype.pickupWhileMoving = function(reverse) {
     return reverse;
   }
 
-  if (_.sum(this.carry) < this.carryCapacity) {
-    let creep = this;
-    // TODO Extract to somewhere (also in creep_harvester, creep_carry, config_creep_resources)
-    let pickableResources = function(object) {
-      return creep.pos.getRangeTo(object.pos.x, object.pos.y) < 2;
-    };
+  if (_.sum(this.carry) === this.carryCapacity) {
+    return reverse;
+  }
 
-    let resources = _.filter(this.room.getDroppedResources(), pickableResources);
+  // TODO Extract to somewhere (also in creep_harvester, creep_carry, config_creep_resources)
+  let resources = _.filter(this.room.getDroppedResources(), this.pickableResources(this));
 
-    if (resources.length > 0) {
-      let resource = Game.getObjectById(resources[0].id);
-      const amount = this.pickupOrWithdrawFromSourcer(resource);
-      return _.sum(this.carry) + amount > 0.5 * this.carryCapacity;
-    }
+  if (resources.length > 0) {
+    let resource = Game.getObjectById(resources[0].id);
+    const amount = this.pickupOrWithdrawFromSourcer(resource);
+    return _.sum(this.carry) + amount > 0.5 * this.carryCapacity;
+  }
 
-    if (this.room.name === this.memory.routing.targetRoom) {
-      let containers = this.pos.findInRange(FIND_STRUCTURES, 1, {
-        filter: (s) => (s.structureType === STRUCTURE_CONTAINER ||
-          s.structureType === STRUCTURE_STORAGE),
-      });
-      for (let container of containers) {
-        this.withdraw(container, RESOURCE_ENERGY);
-        return container.store.energy > 9;
-      }
+  if (this.room.name === this.memory.routing.targetRoom) {
+    let containers = this.pos.findInRange(FIND_STRUCTURES, 1, {
+      filter: (s) => (s.structureType === STRUCTURE_CONTAINER ||
+        s.structureType === STRUCTURE_STORAGE)
+    });
+    for (let container of containers) {
+      this.withdraw(container, RESOURCE_ENERGY);
+      return container.store.energy > 9;
     }
   }
   return reverse;
@@ -134,7 +135,7 @@ Creep.prototype.handleExtractor = function() {
   return true;
 };
 
-Creep.prototype.handleUpgrader = function() {
+Creep.prototype.sayIdiotList = function() {
   let say = function(creep) {
     let players = _.filter(Memory.players, function(object) {
       return object.idiot && object.idiot > 0;
@@ -151,36 +152,76 @@ Creep.prototype.handleUpgrader = function() {
     creep.say(sentence[word], true);
   };
   // say(this);
+};
+
+Creep.prototype.upgraderUpdateStats = function() {
+  if (!this.room.memory.upgraderUpgrade) {
+    this.room.memory.upgraderUpgrade = 0;
+  }
+  var work_parts = 0;
+  for (var part_i in this.body) {
+    if (this.body[part_i].type === 'work') {
+      work_parts++;
+    }
+  }
+  this.room.memory.upgraderUpgrade += Math.min(work_parts, this.carry.energy);
+};
+
+Creep.prototype.handleUpgrader = function() {
+  this.sayIdiotList();
   this.spawnReplacement(1);
-  var room = Game.rooms[this.room.name];
-  if (room.memory.attackTimer > 50 && room.controller.level > 6) {
-    if (room.controller.ticksToDowngrade > 10000) {
+  if (this.room.memory.attackTimer > 50 && this.room.controller.level > 6) {
+    if (this.room.controller.ticksToDowngrade > 10000) {
       return true;
     }
   }
 
   var returnCode = this.upgradeController(this.room.controller);
   if (returnCode === OK) {
-    if (!room.memory.upgraderUpgrade) {
-      room.memory.upgraderUpgrade = 0;
-    }
-    var work_parts = 0;
-    for (var part_i in this.body) {
-      if (this.body[part_i].type === 'work') {
-        work_parts++;
-      }
-    }
-    room.memory.upgraderUpgrade += Math.min(work_parts, this.carry.energy);
+    this.upgraderUpdateStats();
   }
 
   returnCode = this.withdraw(this.room.storage, RESOURCE_ENERGY);
-  if (returnCode === ERR_FULL) {
-    return true;
-  }
-  if (returnCode === OK) {
+  if (returnCode === ERR_FULL || returnCode === OK) {
     return true;
   }
   return true;
+};
+
+Creep.prototype.buildContainerConstructionSite = function() {
+  let returnCode = this.pos.createConstructionSite(STRUCTURE_CONTAINER);
+  if (returnCode === OK) {
+    this.log('Create cs for container');
+    return true;
+  }
+  if (returnCode === ERR_INVALID_TARGET) {
+    let constructionSites = this.pos.findInRange(FIND_CONSTRUCTION_SITES, 0);
+    for (let constructionSite of constructionSites) {
+      constructionSite.remove();
+    }
+    return false;
+  }
+  if (returnCode !== ERR_FULL) {
+    this.log('Container: ' + returnCode + ' pos: ' + this.pos);
+  }
+  return false;
+};
+
+Creep.prototype.buildContainerExecute = function() {
+  if (this.carry.energy < 50) {
+    return false;
+  }
+
+  let constructionSites = this.pos.findInRangeStructures(FIND_CONSTRUCTION_SITES, 0, [STRUCTURE_CONTAINER]);
+  if (constructionSites.length > 0) {
+    let returnCode = this.build(constructionSites[0]);
+    if (returnCode !== OK) {
+      this.log('buildContainerExecute build: ' + returnCode);
+    }
+    return true;
+  }
+
+  return this.buildContainerConstructionSite();
 };
 
 Creep.prototype.buildContainer = function() {
@@ -188,55 +229,13 @@ Creep.prototype.buildContainer = function() {
     return false;
   }
   // TODO Not in base room
-  var objects = this.pos.findInRange(FIND_STRUCTURES, 0, {
-    filter: function(object) {
-      if (object.structureType === STRUCTURE_CONTAINER) {
-        return true;
-      }
-      return false;
-    }
-  });
+  var objects = this.pos.findInRangeStructures(FIND_STRUCTURES, 0, [STRUCTURE_CONTAINER]);
   if (objects.length === 0) {
-    if (this.carry.energy >= 50) {
-      let constructionSites = this.pos.findInRange(FIND_CONSTRUCTION_SITES, 0, {
-        filter: function(object) {
-          if (object.structureType != STRUCTURE_CONTAINER) {
-            return false;
-          }
-          return true;
-        }
-      });
-      if (constructionSites.length > 0) {
-        let returnCode = this.build(constructionSites[0]);
-        if (returnCode != OK) {
-          this.log('build container: ' + returnCode);
-        }
-        return true;
-      }
-
-      let returnCode = this.pos.createConstructionSite(STRUCTURE_CONTAINER);
-      if (returnCode === OK) {
-        this.log('Create cs for container');
-        return true;
-      }
-      if (returnCode === ERR_INVALID_TARGET) {
-        let constructionSites = this.pos.findInRange(FIND_CONSTRUCTION_SITES, 0);
-        for (let constructionSite of constructionSites) {
-          constructionSite.remove();
-        }
-        return false;
-      }
-      if (returnCode != ERR_FULL) {
-        this.log('Container: ' + returnCode + ' pos: ' + this.pos);
-      }
-      return false;
-    }
+    return this.buildContainerExecute();
   }
-  if (objects.length > 0) {
-    let object = objects[0];
-    if (object.hits < object.hitsMax) {
-      this.repair(object);
-    }
+  let object = objects[0];
+  if (object.hits < object.hitsMax) {
+    this.repair(object);
   }
 };
 
@@ -254,14 +253,7 @@ Creep.prototype.pickupEnergy = function() {
     return returnCode === OK;
   }
 
-  let containers = this.pos.findInRange(FIND_STRUCTURES, 1, {
-    filter: function(object) {
-      if (object.structureType === STRUCTURE_CONTAINER) {
-        return true;
-      }
-      return false;
-    }
-  });
+  let containers = this.pos.findInRangeStructures(FIND_STRUCTURES, 1, [STRUCTURE_CONTAINER]);
   if (containers.length > 0) {
     let returnCode = this.withdraw(containers[0], RESOURCE_ENERGY);
     if (returnCode === OK) {
@@ -287,107 +279,121 @@ Creep.prototype.pickupEnergy = function() {
   return false;
 };
 
-// After introduction of `routing` take the direction to transfer to
-Creep.prototype.transferToCreep = function(direction) {
-  // TODO Only forward proper
-  for (var index = -1; index < 2; index++) { // Only forward
-    let indexCalc = (+direction + 7 + index) % 8 + 1;
-    let adjacentPos = this.pos.getAdjacentPosition(indexCalc);
-    if (adjacentPos.x < 0 || adjacentPos.y < 0) {
-      continue;
-    }
-    if (adjacentPos.x > 49 || adjacentPos.y > 49) {
-      continue;
-    }
+let checkCreepForTransfer = function(creep) {
+  if (!Game.creeps[creep.name]) {
+    return false;
+  }
+  // don't transfer to extractor, fixes full terminal with 80% energy?
+  if (Game.creeps[creep.name].memory.role === 'extractor') {
+    return false;
+  }
+  // Do we want this?
+  if (Game.creeps[creep.name].memory.role === 'powertransporter') {
+    return false;
+  }
+  if (creep.carry.energy === creep.carryCapacity) {
+    return false;
+  }
+  return true;
+};
 
-    var creeps = adjacentPos.lookFor('creep');
-    for (var name in creeps) {
-      let otherCreep = creeps[name];
-      if (!Game.creeps[otherCreep.name]) {
-        continue;
-      }
-      // don't transfer to extractor, fixes full terminal with 80% energy?
-      if (Game.creeps[otherCreep.name].memory.role === 'extractor') {
-        continue;
-      }
-      // Do we want this?
-      if (Game.creeps[otherCreep.name].memory.role === 'powertransporter') {
-        continue;
-      }
-      if (otherCreep.carry.energy === otherCreep.carryCapacity) {
-        continue;
-      }
-      var return_code = this.transfer(otherCreep, RESOURCE_ENERGY);
-      if (return_code === OK) {
-        // return true;
-        return this.carry.energy * 0.5 <= otherCreep.carryCapacity - otherCreep.carry.energy;
-      }
+Creep.prototype.transferToCreep = function(direction) {
+  let adjacentPos = this.pos.getAdjacentPosition(direction);
+  if (!adjacentPos.isValid()) {
+    return false;
+  }
+
+  var creeps = adjacentPos.lookFor('creep');
+  for (let i = 0; i < creeps.length; i++) {
+    let otherCreep = creeps[i];
+    if (!checkCreepForTransfer(otherCreep)) {
+      continue;
+    }
+    var return_code = this.transfer(otherCreep, RESOURCE_ENERGY);
+    if (return_code === OK) {
+      return this.carry.energy * 0.5 <= otherCreep.carryCapacity - otherCreep.carry.energy;
     }
   }
   return false;
+};
+
+let canStoreEnergy = function(object) {
+  let structureTypes = [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_WALL, STRUCTURE_RAMPART, STRUCTURE_OBSERVER];
+  if (structureTypes.indexOf(object.structureType) >= 0) {
+    return false;
+  }
+  return true;
+};
+
+let energyAcceptingLink = function(object, room) {
+  if (object.structureType === STRUCTURE_LINK) {
+    for (let i = 0; i < 3; i++) {
+      if (object.pos.isEqualTo(room.memory.position.structure.link[i].x, room.memory.position.structure.link[i].y)) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+let terminalAvailable = function(object) {
+  if (object.structureType === STRUCTURE_TERMINAL && (object.store.energy || 0) > 10000) {
+    return false;
+  }
+  return true;
+};
+
+let harvesterTarget = function(creep, object) {
+  if (creep.memory.role === 'harvester') {
+    if (object.structureType === STRUCTURE_STORAGE || object.structureType === STRUCTURE_LINK) {
+      return false;
+    }
+  }
+  return true;
+};
+
+let filterTransferrables = function(creep, object) {
+  if (!canStoreEnergy(object)) {
+    return false;
+  }
+
+  if (!energyAcceptingLink(object, creep.room)) {
+    return false;
+  }
+
+  if (!terminalAvailable(object)) {
+    return false;
+  }
+
+  if (!harvesterTarget(creep, object)) {
+    return false;
+  }
+
+  if (object.energy === object.energyCapacity) {
+    return false;
+  }
+
+  return true;
+};
+
+Creep.prototype.transferAllResources = function(structure) {
+  let transferred = false;
+  for (let resource in this.carry) {
+    if (!resource) {
+      continue;
+    }
+    let returnCode = this.transfer(structure, resource);
+    if (returnCode === OK) {
+      transferred = Math.min(this.carry[resource], structure.energyCapacity - structure.energy);
+    }
+  }
+  return transferred;
 };
 
 Creep.prototype.transferToStructures = function() {
   if (_.sum(this.carry) === 0) {
     return false;
   }
-
-  let creep = this;
-  let room = creep.room;
-  let filterTransferrables = function(object) {
-    if (object.structureType === STRUCTURE_CONTROLLER) {
-      return false;
-    }
-    if (object.structureType === STRUCTURE_ROAD) {
-      return false;
-    }
-    if (object.structureType === STRUCTURE_WALL) {
-      return false;
-    }
-    if (object.structureType === STRUCTURE_RAMPART) {
-      return false;
-    }
-    if (object.structureType === STRUCTURE_OBSERVER) {
-      return false;
-    }
-
-    if (object.structureType === STRUCTURE_LINK) {
-      if (object.pos.isEqualTo(room.memory.position.structure.link[0].x, room.memory.position.structure.link[0].y)) {
-        return false;
-      }
-      if (object.pos.isEqualTo(room.memory.position.structure.link[1].x, room.memory.position.structure.link[1].y)) {
-        return false;
-      }
-      if (object.pos.isEqualTo(room.memory.position.structure.link[2].x, room.memory.position.structure.link[2].y)) {
-        return false;
-      }
-    }
-
-    if (object.structureType === STRUCTURE_TERMINAL && (object.store.energy || 0) > 10000) {
-      return false;
-    }
-
-    if (creep.memory.role === 'harvester' && object.structureType === STRUCTURE_STORAGE) {
-      return false;
-    }
-
-    if (creep.memory.role === 'harvester' && object.structureType === STRUCTURE_LINK) {
-      return false;
-    }
-
-    if ((object.structureType === STRUCTURE_LAB ||
-        object.structureType === STRUCTURE_EXTENSION ||
-        object.structureType === STRUCTURE_SPAWN ||
-        object.structureType === STRUCTURE_NUKER ||
-        object.structureType === STRUCTURE_POWER_SPAWN ||
-        object.structureType === STRUCTURE_TOWER ||
-        object.structureType === STRUCTURE_LINK) &&
-      object.energy === object.energyCapacity) {
-      return false;
-    }
-
-    return true;
-  };
 
   let transferred = false;
   var look = this.room.lookForAtArea(
@@ -398,7 +404,7 @@ Creep.prototype.transferToStructures = function() {
     Math.max(1, Math.min(48, this.pos.x + 1)),
     true);
   for (let item of look) {
-    if (filterTransferrables(item.structure)) {
+    if (filterTransferrables(this, item.structure)) {
       if (transferred) {
         return {
           moreStructures: true,
@@ -406,57 +412,88 @@ Creep.prototype.transferToStructures = function() {
           transferred: transferred
         };
       }
-      for (let resource in this.carry) {
-        let returnCode = this.transfer(item.structure, resource);
-        if (returnCode === OK) {
-          transferred = Math.min(this.carry[resource], item.structure.energyCapacity - item.structure.energy);
-        }
-      }
+      transferred = this.transferAllResources(item.structure);
     }
   }
   return false;
 };
 
-Creep.prototype.transferMy = function() {
-  var pos;
-  var structures;
-  var structure;
-  var creeps;
-  let otherCreep;
-  var offset;
-  var index;
-  var return_code;
-  var name;
-
-  for (let direction = 1; direction < 9; direction++) {
-    let adjacentPos = this.pos.getAdjacentPosition(direction);
-    if (adjacentPos.x < 0 || adjacentPos.y < 0) {
-      continue;
-    }
-    if (adjacentPos.x > 49 || adjacentPos.y > 49) {
-      continue;
-    }
-    creeps = adjacentPos.lookFor('creep');
-    for (name in creeps) {
-      otherCreep = creeps[name];
-      if (!otherCreep.my) {
-        continue;
+Creep.prototype.getEnergyFromSourcer = function() {
+  let sourcers = this.pos.findInRange(FIND_MY_CREEPS, 1, {
+    filter: function(object) {
+      let creep = Game.getObjectById(object.id);
+      if (creep.memory.role === 'sourcer' && creep.carry.energy > 0) {
+        return true;
       }
-      if (otherCreep.carry.energy === otherCreep.carryCapacity) {
-        continue;
-      }
-      return_code = this.transfer(otherCreep, RESOURCE_ENERGY);
-      return return_code === 0;
+      return false;
+    }
+  });
+  if (sourcers.length > 0) {
+    let returnCode = sourcers[0].transfer(this, RESOURCE_ENERGY);
+    this.say('rr:' + returnCode);
+    if (returnCode === OK) {
+      return true;
     }
   }
   return false;
 };
 
-Creep.prototype.getEnergy = function() {
-  /* State machine:
-   * No energy, goes to collect energy until full.
-   * Full energy, uses energy until empty.
-   */
+Creep.prototype.moveToSource = function(source) {
+  if (!this.memory.routing) {
+    this.memory.routing = {};
+  }
+  this.memory.routing.reverse = false;
+  if (this.room.memory.misplacedSpawn || this.room.controller.level < 3) {
+    this.moveToMy(source.pos);
+  } else {
+    this.moveByPathMy([{
+      'name': this.room.name
+    }], 0, 'pathStart', source.id, true, undefined);
+  }
+  return true;
+};
+
+Creep.prototype.harvestSource = function(source) {
+  let returnCode = this.harvest(source);
+  if (this.carry.energy >= this.carryCapacity) {
+    var creep = this;
+    var creep_without_energy = this.pos.findInRange(FIND_MY_CREEPS, 1, {
+      filter: function(object) {
+        return object.carry.energy === 0 && object.id !== creep.id;
+      }
+    });
+    this.transfer(creep_without_energy, RESOURCE_ENERGY);
+  }
+
+  // TODO Somehow we move before preMove, canceling here
+  this.cancelOrder('move');
+  this.cancelOrder('moveTo');
+  return true;
+};
+
+Creep.prototype.getEnergyFromSource = function() {
+  let source = this.pos.getClosestSource();
+
+  let range = this.pos.getRangeTo(source);
+  if (this.carry.energy > 0 && range > 1) {
+    this.memory.hasEnergy = true; // Stop looking and spend the energy.
+    return false;
+  }
+
+  if (range <= 2) {
+    if (this.getEnergyFromSourcer()) {
+      return true;
+    }
+  }
+
+  if (range === 1) {
+    return this.harvestSource(source);
+  } else {
+    return this.moveToSource(source);
+  }
+};
+
+Creep.prototype.setHasEnergy = function() {
   if (this.memory.hasEnergy === undefined) {
     this.memory.hasEnergy = (this.carry.energy === this.carryCapacity);
   } else if (this.memory.hasEnergy && this.carry.energy === 0) {
@@ -465,6 +502,14 @@ Creep.prototype.getEnergy = function() {
     this.carry.energy === this.carryCapacity) {
     this.memory.hasEnergy = true;
   }
+};
+
+Creep.prototype.getEnergy = function() {
+  /* State machine:
+   * No energy, goes to collect energy until full.
+   * Full energy, uses energy until empty.
+   */
+  this.setHasEnergy();
 
   if (this.memory.hasEnergy) {
     return false;
@@ -482,86 +527,27 @@ Creep.prototype.getEnergy = function() {
     return true;
   }
 
-  var range = null;
-  var item = this.pos.findClosestByRange(FIND_SOURCES_ACTIVE);
+  return this.getEnergyFromSource();
+};
 
-  if (item === null) {
-    if (this.carry.energy === 0) {
-      var source = this.pos.findClosestByRange(FIND_SOURCES);
-      let returnCode = this.moveToMy(source.pos);
-      return true;
-    } else {
-      this.memory.hasEnergy = true; // Stop looking and spend the energy.
-      return false;
-    }
-  }
-
-  range = this.pos.getRangeTo(item);
-  if (this.carry.energy > 0 && range > 1) {
-    this.memory.hasEnergy = true; // Stop looking and spend the energy.
-    return false;
-  }
-
-  if (range === 1) {
-    let sourcers = this.pos.findInRange(FIND_MY_CREEPS, 1, {
-      filter: function(object) {
-        let creep = Game.getObjectById(object.id);
-        if (creep.memory.role === 'sourcer' && creep.carry.energy > 0) {
-          return true;
-        }
-        return false;
-      }
-    });
-    if (sourcers.length > 0) {
-      let returnCode = sourcers[0].transfer(this, RESOURCE_ENERGY);
-      this.say('rr:' + returnCode);
-      if (returnCode === OK) {
-        return true;
-      }
-    }
-  }
-
-  if (typeof(this.memory.target) != 'undefined') {
-    delete this.memory.target;
-  }
-
-  if (range === 1) {
-    let returnCode = this.harvest(item);
-    if (this.carry.energy >= this.carryCapacity) {
-      var creep = this;
-      var creep_without_energy = this.pos.findClosestByRange(FIND_MY_CREEPS, {
-        filter: function(object) {
-          return object.carry.energy === 0 && object.id != creep.id;
-        }
-      });
-      range = this.pos.getRangeTo(creep_without_energy);
-
-      if (range === 1) {
-        this.transfer(creep_without_energy, RESOURCE_ENERGY);
-      }
-    }
-    // TODO Somehow we move before preMove, canceling here
-    this.cancelOrder('move');
-    this.cancelOrder('moveTo');
+Creep.prototype.buildConstructionSite = function(target) {
+  let returnCode = this.build(target);
+  if (returnCode === OK) {
+    this.moveRandomWithin(target.pos);
     return true;
-  } else {
-    if (!this.memory.routing) {
-      this.memory.routing = {};
-    }
-    this.memory.routing.reverse = false;
-    if (this.room.memory.misplacedSpawn || this.room.controller.level < 3) {
-      this.moveTo(item.pos);
-    } else {
-      this.moveByPathMy([{
-        'name': this.room.name
-      }], 0, 'pathStart', item.id, true, undefined);
-    }
+  } else if (returnCode === ERR_NOT_ENOUGH_RESOURCES) {
+    return true;
+  } else if (returnCode === ERR_INVALID_TARGET) {
+    this.log('config_creep_resource construct: ' + returnCode + ' ' + JSON.stringify(target.pos));
+    this.moveRandom();
+    target.pos.clearPosition(target);
     return true;
   }
+  this.log('config_creep_resource construct: ' + returnCode + ' ' + JSON.stringify(target.pos));
+  return false;
 };
 
 Creep.prototype.construct = function() {
-  //   this.say('construct', true);
   var target;
   if (this.memory.role === 'nextroomer') {
     target = this.pos.findClosestByRange(FIND_CONSTRUCTION_SITES, {
@@ -577,215 +563,164 @@ Creep.prototype.construct = function() {
 
   var range = this.pos.getRangeTo(target);
   if (range <= 3) {
-    let returnCode = this.build(target);
-    if (returnCode === OK) {
-      this.moveRandomWithin(target.pos);
-      return true;
-    } else if (returnCode === ERR_NOT_ENOUGH_RESOURCES) {
-      return true;
-    } else if (returnCode === ERR_INVALID_TARGET) {
-      this.log('config_creep_resource construct: ' + returnCode + ' ' + JSON.stringify(target.pos));
-      this.moveRandom();
-
-      let structures = target.pos.lookFor('structure');
-      for (let structureId in structures) {
-        let structure = structures[structureId];
-        if (structure.structureType === STRUCTURE_SPAWN) {
-          let spawns = this.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
-          if (spawns.length <= 1) {
-            target.remove();
-            return true;
-          }
-        }
-        this.log('Destroying: ' + structure.structureType);
-        structure.destroy();
-      }
-      return true;
-    }
-    this.log('config_creep_resource construct: ' + returnCode + ' ' + JSON.stringify(target.pos));
-  } else {
-    let search = PathFinder.search(
-      this.pos, {
-        pos: target.pos,
-        range: 3
-      }, {
-        roomCallback: this.room.getCostMatrixCallback(target.pos, true),
-        maxRooms: 0
-      }
-    );
-
-    if (search.incomplete) {
-      this.moveTo(target.pos);
-      return true;
-    }
-
-    if (range > 5 && search.path.length === 1) {
-      // TODO extract to a method and make sure, e.g. creep doesn't leave the room
-      this.moveRandom();
-      return true;
-    }
-
-    // TODO Stuck?
-    if (!this.pos.getDirectionTo(search.path[0])) {
-      this.moveRandom();
-      return true;
-    }
-
-    let returnCode = this.move(this.pos.getDirectionTo(search.path[0]));
-    if (returnCode != ERR_TIRED) {
-      this.memory.lastPosition = this.pos;
-    }
+    return this.buildConstructionSite(target);
   }
+
+  this.moveToMy(target.pos);
   return true;
 };
 
-Creep.prototype.transferEnergyMy = function() {
-  if (!this.memory.target) {
-    let structure = this.pos.findClosestByRange(FIND_MY_STRUCTURES, {
-      filter: (s) => {
-        if (s.energy === s.energyCapacity) {
-          return false;
-        }
-        return (s.structureType === STRUCTURE_EXTENSION ||
-          s.structureType === STRUCTURE_SPAWN ||
-          s.structureType === STRUCTURE_TOWER);
-      }
-    });
-    if (structure === null) {
-      if (this.room.storage && this.room.storage.my && this.memory.role != 'planer') {
-        this.memory.target = this.room.storage.id;
-      } else {
+Creep.prototype.getTransferTarget = function() {
+  let structure = this.pos.findClosestByRange(FIND_MY_STRUCTURES, {
+    filter: (s) => {
+      if (s.energy === s.energyCapacity) {
         return false;
       }
+      return (s.structureType === STRUCTURE_EXTENSION ||
+        s.structureType === STRUCTURE_SPAWN ||
+        s.structureType === STRUCTURE_TOWER);
+    }
+  });
+  if (structure === null) {
+    if (this.room.storage && this.room.storage.my && this.memory.role !== 'planer') {
+      this.memory.target = this.room.storage.id;
     } else {
-      this.memory.target = structure.id;
+      return false;
+    }
+  } else {
+    this.memory.targetEnergyMy = structure.id;
+  }
+};
+
+Creep.prototype.transferEnergyMy = function() {
+  if (!this.memory.targetEnergyMy) {
+    this.getTransferTarget();
+    if (!this.memory.targetEnergyMy) {
+      return false;
     }
   }
 
-  var target = Game.getObjectById(this.memory.target);
+  var target = Game.getObjectById(this.memory.targetEnergyMy);
   if (!target) {
-    this.log('transferEnergyMy: Can not find target');
-    delete this.memory.target;
+    this.log(`transferEnergyMy: Can not find target ${this.memory.targetEnergyMy}`);
+    delete this.memory.targetEnergyMy;
     return false;
   }
   var range = this.pos.getRangeTo(target);
   if (range === 1) {
     let returnCode = this.transfer(target, RESOURCE_ENERGY);
-    if (returnCode != OK && returnCode != ERR_FULL) {
+    if (returnCode !== OK && returnCode !== ERR_FULL) {
       this.log('transferEnergyMy: ' + returnCode + ' ' +
         target.structureType + ' ' + target.pos);
     }
-    delete this.memory.target;
+    delete this.memory.targetEnergyMy;
   } else {
-    let returnCode = this.moveToMy(target.pos, 1);
-    if (returnCode === false) {
-      this.say('tr:incompl', true);
-      if (config.path.pathfindIncomplete) {
-        this.moveTo(target.pos);
-        return true;
-      }
-    }
+    this.moveToMy(target.pos, 1);
   }
   return true;
 };
 
-Creep.prototype.handleReserver = function() {
-  if (this.room.name != this.memory.routing.targetRoom) {
-    this.memory.routing.reached = false;
-    return false;
-  }
-
+Creep.prototype.reserverSetLevel = function() {
   this.memory.level = 2;
   if (this.room.controller.reservation && this.room.controller.reservation.ticksToEnd > 4500) {
     this.memory.level = 1;
   }
-  if (!this.room.controller.my && this.room.controller.reservation && this.room.controller.reservation.username != Memory.username) {
+  if (!this.room.controller.my && this.room.controller.reservation && this.room.controller.reservation.username !== Memory.username) {
     this.memory.level = 5;
   }
-  this.spawnReplacement(1);
+};
 
-  let callCleaner = function(creep) {
-    if (creep.inBase()) {
-      return false;
+let callStructurer = function(creep) {
+  var structurers = creep.room.find(FIND_MY_CREEPS, {
+    filter: creep.room.findCreep('structurer')
+  });
+  if (structurers.length > 0) {
+    return false;
+  }
+  var resource_structures = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+  if (resource_structures.length > 0 && !creep.room.controller.my) {
+    creep.log('Call structurer from ' + creep.memory.base + ' because of ' + resource_structures[0].structureType);
+    Game.rooms[creep.memory.base].checkRoleToSpawn('structurer', 1, undefined, creep.room.name);
+    return true;
+  }
+};
+
+let callCleaner = function(creep) {
+  if (creep.inBase()) {
+    return false;
+  }
+
+  if (!Game.rooms[creep.memory.base].storage) {
+    return false;
+  }
+
+  if (!creep.room.exectueEveryTicks(1000)) {
+    return false;
+  }
+
+  if (config.creep.structurer) {
+    callStructurer(creep);
+  }
+};
+
+let checkSourcerMatch = function(sourcers, source_id) {
+  for (let i = 0; i < sourcers.length; i++) {
+    var sourcer = Game.creeps[sourcers[i].name];
+    if (sourcer.memory.routing.targetId === source_id) {
+      return true;
     }
+  }
+  return false;
+};
 
-    if (!Game.rooms[creep.memory.base].storage) {
-      return false;
-    }
+let checkSourcer = function(creep) {
+  var sources = creep.room.find(FIND_SOURCES);
+  var sourcer = creep.room.find(FIND_MY_CREEPS, {
+    filter: creep.room.findCreep('sourcer')
+  });
 
-    if (!creep.room.exectueEveryTicks(1000)) {
-      return false;
-    }
-
-    if (config.creep.structurer) {
-      var structurers = creep.room.find(FIND_MY_CREEPS, {
-        filter: function(object) {
-          return object.memory.role === 'structurer';
-        }
-      });
-      if (structurers.length > 0) {
-        return false;
-      }
-      var resource_structures = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
-      if (resource_structures.length > 0 && !creep.room.controller.my) {
-        creep.log('Call structurer from ' + creep.memory.base + ' because of ' + resource_structures[0].structureType);
-        Game.rooms[creep.memory.base].checkRoleToSpawn('structurer', 1, undefined, creep.room.name);
-        return true;
-      }
-    }
-  };
-
-  callCleaner(this);
-
-  if (this.room.exectueEveryTicks(100) && this.room.controller.reservation && this.room.controller.reservation.username === Memory.username) {
-    let checkSourcer = function(creep) {
-      let checkSourcerMatch = function(sourcers, source_id) {
-        for (var sourcer_i in sourcers) {
-          var sourcer = sourcers[sourcer_i];
-          if (sourcer.memory.routing.targetId === source_id) {
-            return true;
-          }
-        }
-        return false;
-      };
-      var sources = creep.room.find(FIND_SOURCES);
-      var sourcer = creep.room.find(FIND_MY_CREEPS, {
-        filter: function(object) {
-          return object.memory.role === 'sourcer';
-        }
-      });
-
-      if (sourcer.length < sources.length) {
-        let sourceParse = function(source) {
-          if (!checkSourcerMatch(sourcer, source.pos)) {
-            Game.rooms[creep.memory.base].checkRoleToSpawn('sourcer', 1, source.id, source.pos.roomName);
-          }
-        };
-        _.each(sources, (sourceParse));
+  if (sourcer.length < sources.length) {
+    let sourceParse = function(source) {
+      if (!checkSourcerMatch(sourcer, source.pos)) {
+        Game.rooms[creep.memory.base].checkRoleToSpawn('sourcer', 1, source.id, source.pos.roomName);
       }
     };
-    checkSourcer(this);
+    _.each(sources, (sourceParse));
   }
+};
 
-  if (config.creep.reserverDefender) {
-    var hostiles = this.room.getEnemys();
-    if (hostiles.length > 0) {
-      //this.log('Reserver under attack');
-      if (!this.memory.defender_called) {
-        Game.rooms[this.memory.base].memory.queue.push({
-          role: 'defender',
-          routing: {
-            targetRoom: this.room.name
-          },
-        });
-        this.memory.defender_called = true;
-      }
+Creep.prototype.callDefender = function() {
+  var hostiles = this.room.getEnemys();
+  if (hostiles.length > 0) {
+    //this.log('Reserver under attack');
+    if (!this.memory.defender_called) {
+      Game.rooms[this.memory.base].memory.queue.push({
+        role: 'defender',
+        routing: {
+          targetRoom: this.room.name
+        }
+      });
+      this.memory.defender_called = true;
     }
   }
+};
 
-  var method = this.reserveController;
+Creep.prototype.interactWithControllerSuccess = function() {
+  if (this.room.controller.reservation) {
+    this.room.memory.reservation = {
+      base: this.memory.base,
+      tick: Game.time,
+      ticksToLive: this.ticksToLive,
+      reservation: this.room.controller.reservation.ticksToEnd
+    };
+  }
+  this.memory.targetReached = true;
+  this.setNextSpawn();
+};
+
+Creep.prototype.interactWithController = function() {
   var return_code;
-  if (this.room.controller.owner && this.room.controller.owner != Memory.username) {
+  if (this.room.controller.owner && this.room.controller.owner !== Memory.username) {
     this.say('attack');
     return_code = this.attackController(this.room.controller);
   } else {
@@ -793,16 +728,7 @@ Creep.prototype.handleReserver = function() {
   }
 
   if (return_code === OK || return_code === ERR_NO_BODYPART) {
-    if (this.room.controller.reservation) {
-      this.room.memory.reservation = {
-        base: this.memory.base,
-        tick: Game.time,
-        ticksToLive: this.ticksToLive,
-        reservation: this.room.controller.reservation.ticksToEnd
-      };
-    }
-    this.memory.targetReached = true;
-    this.setNextSpawn();
+    this.interactWithControllerSuccess();
     return true;
   }
   if (return_code === ERR_NOT_IN_RANGE) {
@@ -813,6 +739,26 @@ Creep.prototype.handleReserver = function() {
   }
 
   this.log('reserver: ' + return_code);
+};
 
+Creep.prototype.handleReserver = function() {
+  if (this.room.name !== this.memory.routing.targetRoom) {
+    this.memory.routing.reached = false;
+    return false;
+  }
+  this.reserverSetLevel();
+  this.spawnReplacement(1);
+
+  callCleaner(this);
+
+  if (this.room.exectueEveryTicks(100) && this.room.controller.reservation && this.room.controller.reservation.username === Memory.username) {
+    checkSourcer(this);
+  }
+
+  if (config.creep.reserverDefender) {
+    this.callDefender();
+  }
+
+  this.interactWithController();
   return true;
 };

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -197,7 +197,6 @@ Creep.prototype.repairStructure = function() {
       delete this.memory.target;
     }
   }
-  this.say('aa');
 
   let nukes = this.room.find(FIND_NUKES);
   if (nukes.length > 0) {

--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -1,7 +1,31 @@
 'use strict';
 
-RoomPosition.prototype.findInRangeStructures = function(structures, range, structureTypes) {
-  return this.findInRange(FIND_STRUCTURES, 1, {
+RoomPosition.prototype.clearPosition = function(target) {
+  let structures = this.lookFor('structure');
+  for (let structureId in structures) {
+    let structure = structures[structureId];
+    if (structure.structureType === STRUCTURE_SPAWN) {
+      let spawns = this.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
+      if (spawns.length <= 1) {
+        target.remove();
+        return true;
+      }
+    }
+    this.log('Destroying: ' + structure.structureType);
+    structure.destroy();
+  }
+};
+
+RoomPosition.prototype.getClosestSource = function() {
+  let source = this.findClosestByRange(FIND_SOURCES_ACTIVE);
+  if (source === null) {
+    source = this.findClosestByRange(FIND_SOURCES);
+  }
+  return source;
+};
+
+RoomPosition.prototype.findInRangeStructures = function(objects, range, structureTypes) {
+  return this.findInRange(objects, 1, {
     filter: function(object) {
       return structureTypes.indexOf(object.structureType) >= 0;
     }
@@ -91,6 +115,16 @@ RoomPosition.prototype.isExit = function() {
     return true;
   }
   return false;
+};
+
+RoomPosition.prototype.isValid = function() {
+  if (this.x < 0 || this.y < 0) {
+    return false;
+  }
+  if (this.x > 49 || this.y > 49) {
+    return false;
+  }
+  return true;
 };
 
 RoomPosition.prototype.validPosition = function() {

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -156,6 +156,9 @@ Room.prototype.getPartsStringDatas = function(parts, energyAvailable) {
   ret.cost = Memory.layoutsCost[parts] || 0;
   ret.parts = global.utils.stringToParts(parts);
   ret.len = ret.parts.length;
+  if (config.debug.spawn) {
+    this.log(`getPartsStringDatas ret: ${JSON.stringify(ret)} parts: ${JSON.stringify(parts)}`);
+  }
   if (ret.cost) {
     ret.fail = ret.cost > energyAvailable;
     return ret;
@@ -227,6 +230,9 @@ Room.prototype.applyAmount = function(input, amount) {
   _.forEach(amount, function(element, index) {
     output += _.repeat(input.charAt(index), element);
   });
+  if (config.debug.spawn) {
+    this.log(`applyAmount input: ${JSON.stringify(input)} amount: ${JSON.stringify(amount)} output: ${JSON.stringify(output)}`);
+  }
   return output;
 };
 
@@ -339,7 +345,6 @@ Room.prototype.getCreepConfig = function(creep) {
  */
 Room.prototype.spawnCreateCreep = function(creep) {
   let spawns = this.getSpawnableSpawns();
-
   if (spawns.length === 0) { return; }
 
   let creepConfig = this.getCreepConfig(creep);
@@ -349,8 +354,8 @@ Room.prototype.spawnCreateCreep = function(creep) {
 
   for (let spawn of spawns) {
     let returnCode = spawn.createCreep(creepConfig.partConfig, creepConfig.name, creepConfig.memory);
-    // this.log('spawnCreateCreep: ' + creepConfig.name + ' ' + returnCode);
     if (returnCode != creepConfig.name) {
+      this.log(`spawnCreateCreep: ${returnCode}`);
       continue;
     }
     brain.stats.modifyRoleAmount(creep.role, 1);

--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -88,10 +88,14 @@ Room.prototype.setFillerArea = function(storagePos, route) {
       let powerSpawnPosIterator = fillerPos.findNearPosition();
       for (let powerSpawnPos of powerSpawnPosIterator) {
         this.memory.position.structure.powerSpawn.push(powerSpawnPos);
+        costMatrix.set(powerSpawnPos.x, powerSpawnPos.y, config.layout.structureAvoid);
+        this.setMemoryCostMatrix(costMatrix);
 
         let towerPosIterator = fillerPos.findNearPosition();
         for (let towerPos of towerPosIterator) {
           this.memory.position.structure.tower.push(towerPos);
+          costMatrix.set(towerPos.x, towerPos.y, config.layout.structureAvoid);
+          this.setMemoryCostMatrix(costMatrix);
           return;
         }
         this.memory.position.structure.powerSpawn.pop();
@@ -448,7 +452,7 @@ Room.prototype.setup = function() {
   let pathLB = this.getMemoryPath(paths_controller[4].name);
   let pathL = this.setLabsTerminal(pathLB);
   let pathI = this.setStructures(path);
-  this.log('path: ' + path.name + ' pathI: ' + pathI + ' length: ' + path.length);
+  this.log('path: ' + paths_sorted[paths_sorted.length - 1].name + ' pathI: ' + pathI + ' length: ' + path.length);
   if (pathI === -1) {
     pathI = path.length - 1;
   }

--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -106,16 +106,8 @@ roles.carry.preMove = function(creep, directions) {
   if (!creep.memory.routing.reverse) {
     reverse = creep.checkForTransfer(directions.forwardDirection);
   }
-  // define minimum carryPercentage to move back to storage
-  let carryPercentage = 0.1;
-  if (creep.room.name === creep.memory.routing.targetRoom) {
-    carryPercentage = config.carry.carryPercentageExtern;
-  }
-  if (creep.inBase()) {
-    carryPercentage = config.carry.carryPercentageBase;
-  }
 
-  if (_.sum(creep.carry) > carryPercentage * creep.carryCapacity) {
+  if (creep.checkEnergyTransfer()) {
     reverse = true;
     if (creep.inBase()) {
       let transferred = creep.transferToStructures();
@@ -130,10 +122,8 @@ roles.carry.preMove = function(creep, directions) {
         reverse = false;
       }
     }
-    // Have to invert the direction
-    let directionTransferInvert = (+directions.backwardDirection + 7) % 8 + 1;
-    if (directionTransferInvert && directionTransferInvert !== null) {
-      let transferred = creep.transferToCreep(directionTransferInvert);
+    if (directions.backwardDirection && directions.backwardDirection !== null) {
+      let transferred = creep.transferToCreep(directions.backwardDirection);
       reverse = !transferred;
     }
   }

--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -18,11 +18,14 @@
 roles.harvester = {};
 
 roles.harvester.settings = {
-  param: ['controller.level'],
+  param: ['controller.level', 'energyAvailable'],
   layoutString: 'MWC',
   amount: {
     1: [2, 1, 1],
-    3: [2, 2, 2],
+    3: {
+      0: [2, 1, 1],
+      400: [2, 2, 2],
+    }
   },
   maxLayoutAmount: 6,
 };

--- a/src/role_nextroomer.js
+++ b/src/role_nextroomer.js
@@ -13,13 +13,18 @@
 roles.nextroomer = {};
 
 roles.nextroomer.died = function(name, creepMemory) {
+  if (!creepMemory || !creepMemory.routing || !creepMemory.routing.route || !creepMemory.routing.routePos) {
+    console.log('DIED', name, 'routing not in memory');
+    return true;
+  }
   let roomName = creepMemory.routing.route[creepMemory.routing.routePos].room;
   let message = `${name} ${roomName} ${JSON.stringify(creepMemory)}`;
   if (roomName === creepMemory.routing.targetRoom) {
     // TODO make underSiege to a counter
   }
   // Works but was annoying due to suppen
-  // console.log('DIED:', message);
+  console.log('DIED:', message);
+  return true;
 };
 
 roles.nextroomer.settings = {


### PR DESCRIPTION
 - Extract findCreepWhichCanTransfer
 - Extract sayIdiotList
 - Reduce complexity for buildContainer
 - Improve `transferToCreep`
 - Extract `filterTransferrables`
 - Delete `transferMy`
 - Remove \'aa\'
 - Extract getEnergyFromSource
 - Improve `construct`
 - Not Build road < RCL 4
 - Delete nextroomer from memory if they died
 - Fix harvester bug, Recover: no creep, < 400 energy available
 - Fix layout issue, where powerspawn and filler area tower are not set in the costmatrix
 - Improve getEnergyFromSource
 - Small creep_resource refactoring
 - Extract `checkEnergyTransfer`
 - Refactor `filterTransferrables`
 - Extract `transferAllResources`
 - Refactor `getEnergyFromSource`
 - Extract `setHasEnergy`
 - Extract `clearPosition`
 - Extract `getTransferTarget`
 - Refactor `handleReserver`
 - transferEnergyMy: Catch case if there are no targets