### PR TITLE
Improve carry percentage config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -124,7 +124,9 @@ global.config = {
 
   carry: {
     size: 200,
-    carryPercentageBase: 0.2,
+    // Percentage should increase from base to target room. Decrease may cause stack on border
+    carryPercentageBase: 0.1,
+    carryPercentageHighway: 0.2,
     carryPercentageExtern: 0.5,
     maxPerTargetPerRoom: 2,
   },

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -39,7 +39,7 @@ Creep.prototype.checkEnergyTransfer = function(otherCreep) {
   }
 
   // define minimum carryPercentage to move back to storage
-  let carryPercentage = 0.1;
+  let carryPercentage = config.carry.carryPercentageHighway;
   if (this.room.name === this.memory.routing.targetRoom) {
     carryPercentage = config.carry.carryPercentageExtern;
   }


### PR DESCRIPTION
- extract highway rooms value into config
- fix infinite loop between base and highway rooms if cary percentage between 0.1 and 0.2