### PR TITLE
[WIP] Introduce enforcement of documentation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+ - introduce documenation changes in the tests

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-sync');
   grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-exec');
 
   grunt.initConfig({
     screeps: {
@@ -214,13 +215,18 @@ module.exports = function(grunt) {
         verbose: true,
         compareUsing: 'md5'
       },
-    }
+
+
+    },
+    exec: {
+      check_for_doc_changes: 'bash check_for_doc_changes.sh'
+    },
   });
 
   grunt.registerTask('default', ['jshint', 'jsbeautifier', 'jscs', 'clean', 'copy:uglify', 'copy:main', 'copy:profiler', 'copy:visualizer', 'screeps']);
   grunt.registerTask('release', ['jshint', 'jsbeautifier', 'jscs', 'clean', 'uglify', 'copy:main', 'requireFile', 'sync']);
   grunt.registerTask('local', ['jshint', 'jsbeautifier', 'jscs', 'clean', 'copy:uglify', 'copy:main', 'copy:profiler', 'copy:visualizer', 'sync']);
-  grunt.registerTask('test', ['jshint', 'jscs']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'exec']);
   grunt.registerTask('dev', ['jshint', 'jsbeautifier', 'jscs']);
   grunt.registerTask('deploy', ['clean', 'copy:uglify', 'copy:main', 'copy:profiler', 'copy:visualizer', 'screeps']);
   grunt.registerTask('requireFile', 'Creates an empty file', function() {

--- a/check_for_doc_changes.sh
+++ b/check_for_doc_changes.sh
@@ -1,0 +1,2 @@
+echo \'Checking if documentation changes are included\';
+test 0 -ne `git log master..HEAD --name-only --pretty=format: | grep \.md | wc -l`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-jshint": "1.1.0",
     "grunt-contrib-uglify": "2.0.0",
+    "grunt-exec": "^2.0.0",
     "grunt-jsbeautifier": "0.2.13",
     "grunt-jscs": "3.0.1",
     "grunt-mocha-test": "0.13.2",


### PR DESCRIPTION
I think the project lacks a lot of documentation, I guess most people ran into that problem.

To enforce improvement of the documentation the CI checks will also check if a markdown file has changed and will fail if not.

It surely will help me to work constantly on the documentation. Being honest each contribution should have a documentation improvement in there anyway, at least in the CHANGELOG.