### PR TITLE
Fix build road on swamps

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -167,8 +167,8 @@ Creep.prototype.stayInRoom = function() {
 };
 
 Creep.prototype.buildRoad = function() {
-  if (this.room.controller && this.room.controller.my &&
-    (this.room.controller.level < 4 || this.room.memory.misplacedSpawn || this.pos.lookFor(LOOK_TERRAIN)[0] === 'swamp')) {
+  if (this.room.controller && this.room.controller.my && this.pos.lookFor(LOOK_TERRAIN)[0] !== 'swamp' &&
+    (this.room.controller.level < 4 || this.room.memory.misplacedSpawn)) {
     return false;
   }
 


### PR DESCRIPTION
Oops... My last change broke building any roads on swamps instead of forcing it building in low RCL rooms. Now it's fixed