### PR TITLE
Auto deploy grafana dashboards

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@ env:
   jquery: true
   node: true
 
+parserOptions:
+  ecmaVersion: 8
+
 # http://eslint.org/docs/rules/
 rules:
   # Possible Errors

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ deployment:
     commands:
       - npm run deploy
       - npm publish || true
+      - nodejs utils/grafana.js
   workspace:
     branch: workspace
     commands:

--- a/grafana/main/db/combined-rooms-datas.json
+++ b/grafana/main/db/combined-rooms-datas.json
@@ -1,0 +1,763 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 258,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 3,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.room.$room.energy.available"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "energy.available",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 4,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.room.$room.energy.capacity"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "energy.capacity",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 7,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.room.$room.storage.energy"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "storage.store.energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 5,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.room.$room.creeps.queue"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "queueLength",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 6,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.room.$room.creeps.into"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "creepsIn",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 8,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.cpu.used"
+              },
+              {
+                "refId": "B",
+                "target": "screeps.$player.cpu.tickLimit"
+              },
+              {
+                "refId": "C",
+                "target": "screeps.$player.cpu.limit"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "cpu",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 9,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.cpu.bucket"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "cpu.bucket",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {
+              "Total - myRooms": "#890F02",
+              "Total - myRooms cpu used": "#890F02"
+            },
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 10,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Total - myRooms",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total CPU Used",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total - myRooms cpu used",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$room.cpu, 4)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(screeps.$player.cpu.used, 'Total CPU Used')"
+              },
+              {
+                "refId": "C",
+                "target": "alias(diffSeries(sumSeries(#B), #A), 'Total - myRooms cpu used')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "cpu by rooms",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "TooAngel",
+            "value": [
+              "TooAngel"
+            ]
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": true,
+          "name": "player",
+          "options": [],
+          "query": "screeps.*",
+          "refresh": 1,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": true,
+          "name": "room",
+          "options": [],
+          "query": "screeps.$player.room.*",
+          "refresh": 1,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Combined rooms datas",
+    "version": 8
+  },
+  "overwrite": true
+}

--- a/grafana/main/db/last-24h-tables.json
+++ b/grafana/main/db/last-24h-tables.json
@@ -1,0 +1,380 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "hideControls": false,
+    "id": 259,
+    "links": [],
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "columns": [
+              {
+                "text": "Avg",
+                "value": "avg"
+              },
+              {
+                "text": "Current",
+                "value": "current"
+              },
+              {
+                "text": "Min",
+                "value": "min"
+              },
+              {
+                "text": "Max",
+                "value": "max"
+              }
+            ],
+            "editable": true,
+            "error": false,
+            "fontSize": "100%",
+            "id": 1,
+            "isNew": true,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 0,
+              "desc": true
+            },
+            "span": 12,
+            "styles": [
+              {
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "date"
+              },
+              {
+                "colorMode": "cell",
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "500",
+                  "1500"
+                ],
+                "type": "number",
+                "unit": "short"
+              }
+            ],
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$room.energy.available, 4)"
+              }
+            ],
+            "timeFrom": "24h",
+            "timeShift": null,
+            "title": "Energy",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Avg",
+                "value": "avg"
+              },
+              {
+                "text": "Current",
+                "value": "current"
+              },
+              {
+                "text": "Min",
+                "value": "min"
+              },
+              {
+                "text": "Max",
+                "value": "max"
+              }
+            ],
+            "editable": true,
+            "error": false,
+            "fontSize": "100%",
+            "id": 2,
+            "isNew": true,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 0,
+              "desc": true
+            },
+            "span": 12,
+            "styles": [
+              {
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "date"
+              },
+              {
+                "colorMode": "cell",
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "2000",
+                  "10000"
+                ],
+                "type": "number",
+                "unit": "short"
+              }
+            ],
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$room.storage.energy, 4)"
+              }
+            ],
+            "timeFrom": "24h",
+            "timeShift": null,
+            "title": "Storage",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Min",
+                "value": "min"
+              },
+              {
+                "text": "Max",
+                "value": "max"
+              }
+            ],
+            "editable": true,
+            "error": false,
+            "fontSize": "100%",
+            "id": 3,
+            "isNew": true,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 0,
+              "desc": true
+            },
+            "span": 12,
+            "styles": [
+              {
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "date"
+              },
+              {
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 8,
+                "pattern": "/.*/",
+                "thresholds": [
+                  "2000",
+                  "10000"
+                ],
+                "type": "number",
+                "unit": "short"
+              },
+              {
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+              }
+            ],
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.room.$room.constroller.progress, #B)",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.room.$room.constroller.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "timeFrom": "24h",
+            "timeShift": null,
+            "title": "Controller percent",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          }
+        ],
+        "title": "Row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [],
+        "title": "New row"
+      }
+    ],
+    "schemaVersion": 12,
+    "sharedCrosshair": false,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "Namahanna",
+            "value": "Namahanna"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "player",
+          "options": [
+            {
+              "selected": true,
+              "text": "Namahanna",
+              "value": "Namahanna"
+            },
+            {
+              "selected": false,
+              "text": "Nevrdid",
+              "value": "Nevrdid"
+            },
+            {
+              "selected": false,
+              "text": "Somotaw",
+              "value": "Somotaw"
+            },
+            {
+              "selected": false,
+              "text": "TooAngel",
+              "value": "TooAngel"
+            },
+            {
+              "selected": false,
+              "text": "Totalschaden",
+              "value": "Totalschaden"
+            },
+            {
+              "selected": false,
+              "text": "Tsungen",
+              "value": "Tsungen"
+            },
+            {
+              "selected": false,
+              "text": "WhiteHalmos",
+              "value": "WhiteHalmos"
+            },
+            {
+              "selected": false,
+              "text": "player2",
+              "value": "player2"
+            }
+          ],
+          "query": "screeps.*",
+          "refresh": 1,
+          "type": "query"
+        },
+        {
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "room",
+          "options": [
+            {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "selected": false,
+              "text": "W6S77",
+              "value": "W6S77"
+            },
+            {
+              "selected": false,
+              "text": "W9S76",
+              "value": "W9S76"
+            },
+            {
+              "selected": false,
+              "text": "W9S79",
+              "value": "W9S79"
+            }
+          ],
+          "query": "screeps.$player.room.*",
+          "refresh": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Last 24h tables",
+    "version": 2
+  },
+  "overwrite": true
+}

--- a/grafana/main/db/players-comparaison.json
+++ b/grafana/main/db/players-comparaison.json
@@ -1,0 +1,915 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "hideControls": false,
+    "id": 260,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 1,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.energy.available, 2, 'sum')"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 2,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.energy.available, 2, 'avg')"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Average energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.energy.available, 2, 'maxSeries')"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Hightest room energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "Row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 6,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.storage.energy, 2, 'sum')"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "groupByNode(screeps.*.room.*.energy.available, 2, 'sum')"
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "sumSeriesWithWildcards(groupByNode(#A,2),4)",
+                "textEditor": true
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Storage energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 8,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.creeps.queue, 2, 'sum')"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total queues length",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 9,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "groupByNode(screeps.$player.room.*.creeps.into, 2, 'sum')"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total creeps",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 5,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.gcl.level, 2)"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "GCL level",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 10,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.gcl.progressTotal, 2)"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.gcl.progress, 2)"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "GCL level",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 4,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.cpu.used, 2)"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU used",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.cpu.bucket, 2)"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU bucket",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "New row"
+      }
+    ],
+    "schemaVersion": 12,
+    "sharedCrosshair": false,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "player",
+          "options": [
+            {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            },
+            {
+              "selected": false,
+              "text": "Namahanna",
+              "value": "Namahanna"
+            },
+            {
+              "selected": false,
+              "text": "Nevrdid",
+              "value": "Nevrdid"
+            },
+            {
+              "selected": false,
+              "text": "Somotaw",
+              "value": "Somotaw"
+            },
+            {
+              "selected": false,
+              "text": "TooAngel",
+              "value": "TooAngel"
+            },
+            {
+              "selected": false,
+              "text": "Totalschaden",
+              "value": "Totalschaden"
+            },
+            {
+              "selected": false,
+              "text": "Tsungen",
+              "value": "Tsungen"
+            },
+            {
+              "selected": false,
+              "text": "WhiteHalmos",
+              "value": "WhiteHalmos"
+            },
+            {
+              "selected": false,
+              "text": "player2",
+              "value": "player2"
+            }
+          ],
+          "query": "screeps.*",
+          "refresh": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Players comparaison",
+    "version": 2
+  },
+  "overwrite": true
+}

--- a/grafana/main/db/rooms-summary.json
+++ b/grafana/main/db/rooms-summary.json
@@ -1,0 +1,4404 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": false,
+    "id": 261,
+    "links": [],
+    "refresh": "1m",
+    "rows": [
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": true,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 18,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.cpu.used, #B)",
+                "textEditor": true
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.cpu.limit"
+              }
+            ],
+            "thresholds": "70,85",
+            "title": "CPU Usage",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(184, 41, 41, 0.9)",
+              "rgba(152, 84, 27, 0.89)",
+              "rgba(16, 69, 14, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 25,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "refId": "A",
+                "target": "screeps.$player.cpu.bucket"
+              }
+            ],
+            "thresholds": "5000,1000",
+            "title": "Bucket",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "aliasColors": {},
+            "cacheTimeout": null,
+            "combine": {
+              "label": "Others",
+              "threshold": 0
+            },
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fontSize": "80%",
+            "format": "short",
+            "height": "200",
+            "id": 77,
+            "interval": null,
+            "legend": {
+              "percentage": true,
+              "show": true,
+              "values": false
+            },
+            "legendType": "Right side",
+            "links": [],
+            "maxDataPoints": 3,
+            "nullPointMode": "connected",
+            "pieType": "donut",
+            "span": 2,
+            "strokeWidth": 1,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.*.energy.available, 4)"
+              }
+            ],
+            "title": "Rooms Energy",
+            "type": "grafana-piechart-panel",
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 78,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(sumSeries(screeps.$player.room.*.energy.available), 'sum')"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.room.*.energy.available, 4)"
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "alias(sumSeries(screeps.$player.room.*.storage.energy), 'sum')"
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.room.*.storage.energy, '#A')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy Available",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "height": "",
+            "id": 41,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Bucket",
+                "yaxis": 2
+              },
+              {
+                "alias": "CPU",
+                "fill": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.cpu.used, 'CPU')",
+                "textEditor": false
+              },
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.cpu.bucket, 'Bucket')"
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(movingAverage(screeps.$player.cpu.used, '5min'), 'CPU avg')"
+              },
+              {
+                "refId": "D",
+                "target": "screeps.$player.cpu.limit"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU/Bucket",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "s",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 60,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "s",
+            "postfixFontSize": "100%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "alias(perSecond(movingAverage(screeps.$player.gcl.progress, '1hour')), 'Progress Rate')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(diffSeries(screeps.$player.gcl.progressTotal, #D), 'Progress to go')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersForecast(divideSeries(#B, #A)), 'Rem')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.gcl.progress, 'Progress')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "43200,86400",
+            "title": "GCL Time",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(62, 8, 62, 0.9)",
+              "rgba(20, 77, 112, 0.9)",
+              "rgba(32, 119, 29, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "height": "",
+            "id": 59,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "150%",
+            "prefix": "",
+            "prefixFontSize": "150%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.gcl.progress, #B)",
+                "textEditor": true
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.gcl.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "50,75",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "GCL Progress",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 50,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": 30,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "AVG",
+                "fill": 0
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(sumSeries(perSecond(screeps.$player.gcl.progress)), 'Total')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(movingAverage(sumSeries(perSecond(screeps.$player.gcl.progress)), '5min'), 'AVG')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "GCL Rate",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {
+              "Progress": "#7EB26D",
+              "Total": "#1F78C1"
+            },
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "height": "",
+            "id": 5,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Total",
+                "fillBelowTo": "Progress",
+                "lines": true
+              },
+              {
+                "alias": "Progress",
+                "fill": 5,
+                "lines": true
+              },
+              {
+                "alias": "Delta Progress",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progressTotal, 'Total')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "highestAverage(screeps.$player.room.$rooms.constroller.progress, 5)",
+                "textEditor": false
+              },
+              {
+                "refId": "D",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '10min'), 'Delta Progress')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Room Controller Upgrade",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "s",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 43,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "s",
+            "postfixFontSize": "100%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "alias(perSecond(movingAverage(screeps.$player.room.$rooms.constroller.progress, '1hour')), 'Progress Rate')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(diffSeries(screeps.$player.room.$rooms.constroller.progressTotal, #D), 'Progress to go')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersForecast(divideSeries(#B, #A)), 'Rem')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "E",
+                "target": "alias(screeps.$player.room.$rooms.constroller.preCalcSpeed, 'Progress Rate')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "86400,172800",
+            "title": "RCL Time",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(62, 8, 62, 0.9)",
+              "rgba(20, 77, 112, 0.9)",
+              "rgba(32, 119, 29, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "height": "",
+            "id": 10,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "150%",
+            "prefix": "",
+            "prefixFontSize": "150%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.room.$rooms.constroller.progress, #B)",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.room.$rooms.constroller.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "50,75",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Progress",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 42,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Storage",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.available, 'Available')"
+              },
+              {
+                "refId": "C",
+                "target": "alias(screeps.$player.room.$rooms.storage.energy, 'Storage')"
+              },
+              {
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.energy.sources, 'Sources')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 51,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "AVG",
+                "fill": 0
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(perSecond(screeps.$player.room.$rooms.constroller.progress), 'Total')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '5min'), 'AVG')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Praising",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 32,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "sideWidth": 100,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.into, 6)",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.queue, 6)",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Creeps",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Capacity": "#0A437C",
+              "energyAvailable": "#EAB839",
+              "energyCapacityAvailable": "#0A437C",
+              "screeps.room.$rooms.energyAvailable": "#629E51",
+              "screeps.room.$rooms.energyCapacityAvailable": "#0A437C"
+            },
+            "bars": true,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 1,
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": false,
+            "linewidth": 2,
+            "links": [
+              {
+                "targetBlank": true,
+                "title": "Main Room",
+                "type": "absolute",
+                "url": "https://screeps.com/a/#!/room/$controllerProgress"
+              }
+            ],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W71N71",
+                "value": "W71N71"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.energy.available, 3), 'Current')"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')"
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.storage.energy, 3), 'Stored')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "D",
+                "target": ""
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy Usage",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": "rooms",
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "$rooms",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {
+              "Progress": "#7EB26D",
+              "Total": "#1F78C1"
+            },
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "height": "",
+            "id": 79,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Total",
+                "fillBelowTo": "Progress",
+                "lines": true
+              },
+              {
+                "alias": "Progress",
+                "fill": 5,
+                "lines": true
+              },
+              {
+                "alias": "Delta Progress",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progressTotal, 'Total')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "highestAverage(screeps.$player.room.$rooms.constroller.progress, 5)",
+                "textEditor": false
+              },
+              {
+                "refId": "D",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '10min'), 'Delta Progress')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Room Controller Upgrade",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "s",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 80,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "s",
+            "postfixFontSize": "100%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "alias(perSecond(movingAverage(screeps.$player.room.$rooms.constroller.progress, '1hour')), 'Progress Rate')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(diffSeries(screeps.$player.room.$rooms.constroller.progressTotal, #D), 'Progress to go')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersForecast(divideSeries(#B, #A)), 'Rem')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "E",
+                "target": "alias(screeps.$player.room.$rooms.constroller.preCalcSpeed, 'Progress Rate')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "86400,172800",
+            "title": "RCL Time",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(62, 8, 62, 0.9)",
+              "rgba(20, 77, 112, 0.9)",
+              "rgba(32, 119, 29, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "height": "",
+            "id": 81,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "150%",
+            "prefix": "",
+            "prefixFontSize": "150%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.room.$rooms.constroller.progress, #B)",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.room.$rooms.constroller.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "50,75",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Progress",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 85,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Storage",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.available, 'Available')"
+              },
+              {
+                "refId": "C",
+                "target": "alias(screeps.$player.room.$rooms.storage.energy, 'Storage')"
+              },
+              {
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.energy.sources, 'Sources')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 82,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "AVG",
+                "fill": 0
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(perSecond(screeps.$player.room.$rooms.constroller.progress), 'Total')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '5min'), 'AVG')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Praising",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 83,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": 100,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.into, 6)",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.queue, 6)",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Creeps",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Capacity": "#0A437C",
+              "energyAvailable": "#EAB839",
+              "energyCapacityAvailable": "#0A437C",
+              "screeps.room.$rooms.energyAvailable": "#629E51",
+              "screeps.room.$rooms.energyCapacityAvailable": "#0A437C"
+            },
+            "bars": true,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 84,
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": false,
+            "linewidth": 2,
+            "links": [
+              {
+                "targetBlank": true,
+                "title": "Main Room",
+                "type": "absolute",
+                "url": "https://screeps.com/a/#!/room/$controllerProgress"
+              }
+            ],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W72N71",
+                "value": "W72N71"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.energy.available, 3), 'Current')"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')"
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.storage.energy, 3), 'Stored')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "D",
+                "target": ""
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy Usage",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": 1486094027389,
+        "repeatRowId": 3,
+        "showTitle": true,
+        "title": "$rooms",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {
+              "Progress": "#7EB26D",
+              "Total": "#1F78C1"
+            },
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "height": "",
+            "id": 86,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Total",
+                "fillBelowTo": "Progress",
+                "lines": true
+              },
+              {
+                "alias": "Progress",
+                "fill": 5,
+                "lines": true
+              },
+              {
+                "alias": "Delta Progress",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progressTotal, 'Total')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "highestAverage(screeps.$player.room.$rooms.constroller.progress, 5)",
+                "textEditor": false
+              },
+              {
+                "refId": "D",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '10min'), 'Delta Progress')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Room Controller Upgrade",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "s",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 87,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "s",
+            "postfixFontSize": "100%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "alias(perSecond(movingAverage(screeps.$player.room.$rooms.constroller.progress, '1hour')), 'Progress Rate')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(diffSeries(screeps.$player.room.$rooms.constroller.progressTotal, #D), 'Progress to go')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersForecast(divideSeries(#B, #A)), 'Rem')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "E",
+                "target": "alias(screeps.$player.room.$rooms.constroller.preCalcSpeed, 'Progress Rate')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "86400,172800",
+            "title": "RCL Time",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(62, 8, 62, 0.9)",
+              "rgba(20, 77, 112, 0.9)",
+              "rgba(32, 119, 29, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "height": "",
+            "id": 88,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "150%",
+            "prefix": "",
+            "prefixFontSize": "150%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.room.$rooms.constroller.progress, #B)",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.room.$rooms.constroller.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "50,75",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Progress",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 92,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Storage",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.available, 'Available')"
+              },
+              {
+                "refId": "C",
+                "target": "alias(screeps.$player.room.$rooms.storage.energy, 'Storage')"
+              },
+              {
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.energy.sources, 'Sources')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 89,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "AVG",
+                "fill": 0
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(perSecond(screeps.$player.room.$rooms.constroller.progress), 'Total')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '5min'), 'AVG')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Praising",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 90,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": 100,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.into, 6)",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.queue, 6)",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Creeps",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Capacity": "#0A437C",
+              "energyAvailable": "#EAB839",
+              "energyCapacityAvailable": "#0A437C",
+              "screeps.room.$rooms.energyAvailable": "#629E51",
+              "screeps.room.$rooms.energyCapacityAvailable": "#0A437C"
+            },
+            "bars": true,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 91,
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": false,
+            "linewidth": 2,
+            "links": [
+              {
+                "targetBlank": true,
+                "title": "Main Room",
+                "type": "absolute",
+                "url": "https://screeps.com/a/#!/room/$controllerProgress"
+              }
+            ],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W73N74",
+                "value": "W73N74"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.energy.available, 3), 'Current')"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')"
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.storage.energy, 3), 'Stored')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "D",
+                "target": ""
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy Usage",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": 1486094027389,
+        "repeatRowId": 3,
+        "showTitle": true,
+        "title": "$rooms",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {
+              "Progress": "#7EB26D",
+              "Total": "#1F78C1"
+            },
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "height": "",
+            "id": 94,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Total",
+                "fillBelowTo": "Progress",
+                "lines": true
+              },
+              {
+                "alias": "Progress",
+                "fill": 5,
+                "lines": true
+              },
+              {
+                "alias": "Delta Progress",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progressTotal, 'Total')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "C",
+                "target": "highestAverage(screeps.$player.room.$rooms.constroller.progress, 5)",
+                "textEditor": false
+              },
+              {
+                "refId": "D",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '10min'), 'Delta Progress')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Room Controller Upgrade",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "s",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 95,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "s",
+            "postfixFontSize": "100%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": true
+            },
+            "targets": [
+              {
+                "hide": true,
+                "refId": "A",
+                "target": "alias(perSecond(movingAverage(screeps.$player.room.$rooms.constroller.progress, '1hour')), 'Progress Rate')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "alias(diffSeries(screeps.$player.room.$rooms.constroller.progressTotal, #D), 'Progress to go')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersForecast(divideSeries(#B, #A)), 'Rem')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.constroller.progress, 'Progress')",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "E",
+                "target": "alias(screeps.$player.room.$rooms.constroller.preCalcSpeed, 'Progress Rate')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "86400,172800",
+            "title": "RCL Time",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(62, 8, 62, 0.9)",
+              "rgba(20, 77, 112, 0.9)",
+              "rgba(32, 119, 29, 0.97)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 1,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "height": "",
+            "id": 96,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "150%",
+            "prefix": "",
+            "prefixFontSize": "150%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.$player.room.$rooms.constroller.progress, #B)",
+                "textEditor": false
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.$player.room.$rooms.constroller.progressTotal",
+                "textEditor": false
+              }
+            ],
+            "thresholds": "50,75",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Progress",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 100,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Storage",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.available, 'Available')"
+              },
+              {
+                "refId": "C",
+                "target": "alias(screeps.$player.room.$rooms.storage.energy, 'Storage')"
+              },
+              {
+                "refId": "D",
+                "target": "alias(screeps.$player.room.$rooms.energy.sources, 'Sources')"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 97,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "seriesOverrides": [
+              {
+                "alias": "AVG",
+                "fill": 0
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "alias(perSecond(screeps.$player.room.$rooms.constroller.progress), 'Total')",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "alias(movingAverage(perSecond(screeps.$player.room.$rooms.constroller.progress), '5min'), 'AVG')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "RCL Praising",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 98,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "sideWidth": 100,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.into, 6)",
+                "textEditor": false
+              },
+              {
+                "refId": "B",
+                "target": "aliasByNode(screeps.$player.room.$rooms.creeps.queue, 6)",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Creeps",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Capacity": "#0A437C",
+              "energyAvailable": "#EAB839",
+              "energyCapacityAvailable": "#0A437C",
+              "screeps.room.$rooms.energyAvailable": "#629E51",
+              "screeps.room.$rooms.energyCapacityAvailable": "#0A437C"
+            },
+            "bars": true,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 99,
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": false,
+            "linewidth": 2,
+            "links": [
+              {
+                "targetBlank": true,
+                "title": "Main Room",
+                "type": "absolute",
+                "url": "https://screeps.com/a/#!/room/$controllerProgress"
+              }
+            ],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeatIteration": 1484577482262,
+            "scopedVars": {
+              "rooms": {
+                "selected": false,
+                "text": "W76N69",
+                "value": "W76N69"
+              }
+            },
+            "seriesOverrides": [],
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.energy.available, 3), 'Current')"
+              },
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.room.$rooms.energy.capacity, 'Capacity')"
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(holtWintersAberration(screeps.$player.room.$rooms.storage.energy, 3), 'Stored')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "D",
+                "target": ""
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Energy Usage",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": 1486094027389,
+        "repeatRowId": 3,
+        "showTitle": true,
+        "title": "$rooms",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "100px",
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 22,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.Start, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Init",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 19,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.CreepManagers, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Creep Manager",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 21,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.SetupRoles, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Setup Roles",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 20,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.Creeps, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Creep Func",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 23,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.Towers, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Towers",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(27, 101, 24, 0.97)",
+              "rgba(136, 74, 22, 0.89)",
+              "rgba(182, 42, 42, 0.9)"
+            ],
+            "datasource": "tooangels",
+            "decimals": 0,
+            "editable": true,
+            "error": false,
+            "format": "percent",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 24,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 2,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "hide": false,
+                "refId": "A",
+                "target": "asPercent(screeps.cpu.Links, #B)"
+              },
+              {
+                "hide": true,
+                "refId": "B",
+                "target": "screeps.cpu.limit"
+              }
+            ],
+            "thresholds": "80,90",
+            "title": "Links",
+            "type": "singlestat",
+            "valueFontSize": "100%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "CPU",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "height": "",
+            "id": 69,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Bucket",
+                "yaxis": 2
+              },
+              {
+                "alias": "CPU",
+                "fill": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "hide": false,
+                "refId": "B",
+                "target": "alias(screeps.$player.cpu.used, 'CPU')",
+                "textEditor": false
+              },
+              {
+                "refId": "A",
+                "target": "alias(screeps.$player.cpu.bucket, 'Bucket')",
+                "textEditor": false
+              },
+              {
+                "hide": false,
+                "refId": "C",
+                "target": "alias(movingAverage(screeps.$player.cpu.used, '5min'), 'CPU avg')"
+              },
+              {
+                "hide": false,
+                "refId": "D",
+                "target": "alias(screeps.$player.cpu.limit, 'Limit')",
+                "textEditor": false
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU/Bucket",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": "350px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "tooangels",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 93,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 12,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "refId": "A",
+                "target": "aliasByNode(screeps.Nevrdid.roles.*, 4)",
+                "textEditor": true
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Creeps by role",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 1,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "New row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "screeps"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "Nevrdid",
+            "value": "Nevrdid"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "player",
+          "options": [],
+          "query": "screeps.*",
+          "refresh": 1,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allFormat": "regex values",
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "tooangels",
+          "hide": 0,
+          "includeAll": true,
+          "label": null,
+          "multi": true,
+          "multiFormat": "glob",
+          "name": "rooms",
+          "options": [],
+          "query": "screeps.$player.room.*",
+          "refresh": 1,
+          "refresh_on_load": true,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "screeps.rooms.$tag.level",
+          "tags": [],
+          "tagsQuery": "screeps.rooms.*",
+          "type": "query",
+          "useTags": true
+        }
+      ]
+    },
+    "time": {
+      "from": "now-3h",
+      "to": "now"
+    },
+    "timepicker": {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "1s",
+        "3s",
+        "10s",
+        "15s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
+    },
+    "timezone": "browser",
+    "title": "Rooms Summary",
+    "version": 11
+  },
+  "overwrite": true
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "grunt-screeps": "1.2.1",
     "grunt-sync": "0.6.2",
     "mocha": "3.2.0",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4",
     "screeps-profiler": "1.2.1",
     "uglify-js-harmony": "2.6.2"
   },

--- a/utils/grafana.js
+++ b/utils/grafana.js
@@ -1,0 +1,89 @@
+var rp = require('request-promise-native');
+var fs = require('fs');
+
+let token = process.env.grafana_tooangel_token;
+
+async function getDashboard(name) {
+  let url = 'https://screepspl.us/grafana/api/dashboards/' + name;
+  let dashboard = await rp.get({
+    uri: url,
+    auth: {
+      'bearer': token
+    },
+    json: true
+  });
+  return dashboard
+}
+
+async function getDashboardList() {
+  let url = 'https://screepspl.us/grafana/api/search';
+  let list = await rp.get({
+    uri: url,
+    auth: {
+      'bearer': token
+    },
+    json: true
+  });
+  return list;
+}
+
+async function getDashboards() {
+  let list = await getDashboardList();
+
+  let dashboards = {};
+  for (let item of Object.keys(list)) {
+    let path = list[item].uri;
+    console.log(path);
+    var obj = JSON.parse(fs.readFileSync('grafana/main/' + path + '.json', 'utf8'));
+    let dashboard = await getDashboard(path);
+    if (obj.dashboard.version === dashboard.dashboard.version) {
+      continue;
+    }
+    if (obj.dashboard.version < dashboard.dashboard.version) {
+      console.log(`Dashboard: ${JSON.stringify(dashboard)}`);
+      console.log(`File: ${JSON.stringify(obj)}`);
+      throw Error(`Dashboard ${path} was changed online`);
+    }
+    console.log(`Updating ${path}`);
+    updateDashboard(path);
+    break
+  }
+
+}
+
+async function updateDashboard(path) {
+  var obj = JSON.parse(fs.readFileSync('grafana/main/' + path + '.json', 'utf8'));
+
+  let url = 'https://screepspl.us/grafana/api/search';
+  url = 'https://screepspl.us/grafana/api/dashboards/db';
+  console.log(url);
+
+  var options = {
+    uri: url,
+    method: 'POST',
+    json: obj,
+    auth: {
+      bearer: token
+    }
+  };
+
+  let response = await rp(options);
+  console.log(response);
+}
+
+async function fetchDashboards() {
+  let list = await getDashboardList();
+  for (item of Object.keys(list)) {
+    let dashboard = await getDashboard(list[item].uri);
+    fs.writeFileSync('grafana/tmp/' + list[item].uri + '.json', JSON.stringify(dashboard), 'utf8');
+  }
+}
+
+function main() {
+  getDashboards();
+
+  // To download dashboard uncomment
+  //fetchDashboards();
+}
+
+main();


### PR DESCRIPTION
Including the grafana dashboards in the repository. On deploy
the dashboards are checked and deployed if the version is newer.

If the online version is newer an exception is thrown.

This enables every contributor to suggest and deploy changes to
the dashboard configuration.