### PR TITLE
fixed harvesters in rooms with misplaced spawns

### DIFF
--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -27,7 +27,7 @@ roles.harvester.settings = {
       400: [1, 1, 1]
     }
   },
-  maxLayoutAmount: 6,
+  maxLayoutAmount: 6
 };
 roles.harvester.updateSettings = function(room, creep) {
   if (room.storage && room.storage.store.energy > config.creep.energyFromStorageThreshold) {
@@ -58,7 +58,7 @@ roles.harvester.preMove = function(creep, directions) {
   creep.setNextSpawn();
   creep.spawnReplacement(1);
 
-  if (!creep.room.storage || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
+  if (!creep.room.storage || creep.room.memory.misplacedSpawn || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
     creep.harvesterBeforeStorage();
     creep.memory.routing.reached = true;
     return true;


### PR DESCRIPTION
TooAngel gave me the extra check in the role_harvester after we saw my room die after building its storage at RCL 4. It seems to have gotten my room back online.