### PR TITLE
Fix carry spawn rate for low RCL

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -133,6 +133,7 @@ global.config = {
       1800: [8, 15], // RCL 5
       2300: [11, 21], // RCL 6
     },
+    minSpawnRate: 50,
     // Percentage should increase from base to target room. Decrease may cause stack on border
     carryPercentageBase: 0.1,
     carryPercentageHighway: 0.2,

--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -85,5 +85,5 @@ Creep.prototype.spawnCarry = function() {
   if (resourceAtPosition > carryCapacity) {
     Game.rooms[this.memory.base].checkRoleToSpawn('carry', 0, this.memory.routing.targetId, this.memory.routing.targetRoom);
   }
-  this.memory.wait = waitTime;
+  this.memory.wait = Math.max(waitTime, config.carry.minSpawnRate);
 };


### PR DESCRIPTION
Carries is spawned faster then they can move to sourcer to change dropped resource amount