### PR TITLE
Fix layouts with no filler position

### DIFF
--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -26,7 +26,7 @@ RoomPosition.prototype.clearPosition = function(target) {
         return true;
       }
     }
-    this.log('Destroying: ' + structure.structureType);
+    console.log('Destroying: ' + structure.structureType);
     structure.destroy();
   }
 };
@@ -187,7 +187,15 @@ RoomPosition.prototype.validPosition = function() {
   return true;
 };
 
-RoomPosition.prototype.findNearPosition = function*() {
+RoomPosition.prototype.getFirstNearPosition = function() {
+  return this.findNearPosition().next().value;
+};
+
+RoomPosition.prototype.getBestNearPosition = function() {
+  return _.max(Array.from(this.findNearPosition()), pos => Array.from(pos.findNearPosition()).length);
+};
+
+RoomPosition.prototype.findNearPosition = function* () {
   for (let posNew of this.getAllAdjacentPositions()) {
     if (!posNew.validPosition()) {
       //        console.log(posNew + ' - invalid');


### PR DESCRIPTION
we have a such chain:
```
controller - upgrader - storage - pathStart
                               \- filler
```
where each next position was first valid adjacent position
in this cange instead of first valid position, "best" valid position will be taken, where "best" is position, which have the biggest number of valid positions adjacent to it
- By taking best position instead of first for upgrader, we reserve some space for potentially several -
upgraders
- By taking best position instead of first for storage, we increase chances that we will have enough positions for pathStart, roads and filer
- For pathStart, first position is enough