### PR TITLE
Mineral handling improvement

### DIFF
--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -53,32 +53,33 @@ Creep.buildRoads = function(creep) {
     return false;
   }
 
-  // TODO Redo for all path in room
-  const path = room.memory.position.path;
-  for (const pathIndex of Object.keys(path)) {
-    const pos = new RoomPosition(
-      path[pathIndex].x,
-      path[pathIndex].y,
-      creep.room.name
-    );
-    if (checkForRoad(pos)) {
-      continue;
-    }
+  for (const pathName of Object.keys(room.getMemoryPaths())) {
+    const path = room.getMemoryPath(pathName);
+    for (const pathIndex of Object.keys(path)) {
+      const pos = new RoomPosition(
+        path[pathIndex].x,
+        path[pathIndex].y,
+        creep.room.name
+      );
+      if (checkForRoad(pos)) {
+        continue;
+      }
 
-    const returnCode = pos.createConstructionSite(STRUCTURE_ROAD);
-    if (returnCode === OK) {
+      const returnCode = pos.createConstructionSite(STRUCTURE_ROAD);
+      if (returnCode === OK) {
+        return true;
+      }
+      if (returnCode === ERR_FULL) {
+        return true;
+      }
+      if (returnCode === ERR_INVALID_TARGET) {
+        // FIXME Creep is standing on constructionSite, need to check why it is not building
+        creep.moveRandom();
+        continue;
+      }
+      creep.log('buildRoads: ' + returnCode + ' pos: ' + JSON.stringify(pos));
       return true;
     }
-    if (returnCode === ERR_FULL) {
-      return true;
-    }
-    if (returnCode === ERR_INVALID_TARGET) {
-      // FIXME Creep is standing on constructionSite, need to check why it is not building
-      creep.moveRandom();
-      continue;
-    }
-    creep.log('buildRoads: ' + returnCode + ' pos: ' + JSON.stringify(pos));
-    return true;
   }
   return false;
 };

--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -106,19 +106,8 @@ RoomPosition.prototype.checkForObstacleStructure = function() {
 };
 
 RoomPosition.prototype.inPath = function() {
-  // if (true) {
-  //   throw new Error();
-  // }
   const room = this.getRoom();
-  for (const pathName of Object.keys(room.getMemoryPaths())) {
-    const path = room.getMemoryPath(pathName);
-    for (const pos of path) {
-      if (this.isEqualTo(pos.x, pos.y)) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return room.getMemoryPathsSet()[`${this.x} ${this.y}`];
 };
 
 RoomPosition.prototype.inPositions = function() {
@@ -227,6 +216,19 @@ RoomPosition.wrapFindMethod = (methodName, extraParamsCount) => function(findTar
     return this[methodName](findTarget, ...extraParams, Room.getPropertyFilterOptsObj(...propertyFilterParams));
   }
   /* eslint-enable no-invalid-this */
+};
+
+/**
+ * Restore RoomPosition object after JSON serialisation.
+ *
+ * @param {object} json JSON object
+ * @param {number} json.x X coordinate
+ * @param {number} json.y Y coordinate
+ * @param {string} json.roomName Name of the room
+ * @return {RoomPosition} RoomPosition object
+ */
+RoomPosition.fromJSON = function(json) {
+  return new RoomPosition(json.x, json.y, json.roomName);
 };
 
 /**

--- a/src/prototype_room_basebuilder.js
+++ b/src/prototype_room_basebuilder.js
@@ -323,13 +323,14 @@ Room.prototype.buildStructures = function() {
     return true;
   }
 
+  if (this.setupStructure(STRUCTURE_TERMINAL)) {
+    return true;
+  }
+
   if (this.setupStructure(STRUCTURE_LAB)) {
     return true;
   }
 
-  if (this.setupStructure(STRUCTURE_TERMINAL)) {
-    return true;
-  }
   if (this.setupStructure(STRUCTURE_NUKER)) {
     return true;
   }

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -61,7 +61,6 @@ Room.prototype.setCostMatrixPath = function(costMatrix, path) {
     const pos = path[i];
     costMatrix.set(pos.x, pos.y, config.layout.pathAvoid);
   }
-  this.setCostMatrixAvoidSources(costMatrix);
 };
 
 Room.prototype.increaseCostMatrixValue = function(costMatrix, pos, value) {

--- a/src/prototype_room_market.js
+++ b/src/prototype_room_market.js
@@ -53,8 +53,7 @@ Room.prototype.sellByOthersOrders = function(sellAmount, resource) {
 };
 
 Room.prototype.sellOwnMineral = function() {
-  const minerals = this.find(FIND_MINERALS);
-  const resource = minerals[0].mineralType;
+  const resource = this.getMineralType();
 
   if (!this.terminal.store[resource]) {
     return false;

--- a/src/prototype_room_memory.js
+++ b/src/prototype_room_memory.js
@@ -113,6 +113,18 @@ Room.prototype.getMemoryPaths = function() {
   return cache.rooms[this.name].routing;
 };
 
+Room.prototype.getMemoryPathsSet = function() {
+  this.checkCache();
+  const mem = cache.rooms[this.name].pathSet = cache.rooms[this.name].pathSet || {};
+  for (const pathName of Object.keys(this.getMemoryPaths())) {
+    const path = this.getMemoryPath(pathName);
+    for (const pos of path) {
+      mem[`${pos.x} ${pos.y}`] = true;
+    }
+  }
+  return mem;
+};
+
 /**
  * Returns the path for the given name. Checks for validity and populated
  * cache if missing.
@@ -158,6 +170,7 @@ Room.prototype.deleteMemoryPaths = function() {
   this.checkCache();
   cache.rooms[this.name].routing = {};
   delete this.memory.routing;
+  cache.rooms[this.name].pathSet = {};
 };
 
 /**
@@ -169,6 +182,7 @@ Room.prototype.deleteMemoryPath = function(name) {
   this.checkCache();
   delete cache.rooms[this.name].routing[name];
   delete this.memory.routing[name];
+  cache.rooms[this.name].pathSet = {};
 };
 
 /**
@@ -197,6 +211,7 @@ Room.prototype.setMemoryPath = function(name, path, fixed) {
     };
     this.memory.routing[name] = memoryData;
   }
+  cache.rooms[this.name].pathSet = {};
 };
 
 /**


### PR DESCRIPTION
improve performance of RoomPosition.inPath
fix planer build roads task
swap lab and terminal construct priorities
refactor out costMatrixSetSourcePath

- refactor setFillerArea
- move terminal near to fillerPos
- change labs layout to improve reaction perfomance (two fixed source labs, all other - result labs)
- move labs as near to pathStart as possible (on any path)

improve resource balansing between storage and terminal
- delete such code from mineral creep
- implement new one in storage filler
- smarter balancing of minerals

Add labs position
Refactor reaction result amount

No layout version bump - waiting for sparr's #457

TODO:
- improve lab reaction handling logic to use new layout (several result labs)
- improve mineral creep logic - split into to creeps: miner and carry