### PR TITLE
[WIP] efficient scouts

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -176,6 +176,7 @@ global.config = {
       7: 1,
       8: 1
     },
+    maxPaternSize: 100,
     revive: true,
     rebuildLayout: 7654,
     handleNukeAttackInterval: 132,

--- a/src/config.js
+++ b/src/config.js
@@ -159,6 +159,11 @@ global.config = {
     swarmSourceHarvestingMaxParts: 10
   },
 
+  scout: {
+    amount: [1,2,3,4,5,6,7,8],   // by RCL
+    intervalBetweenRoomVisit: 500,
+    scoutSkipWhenStuck: true, // Useful for novice areas.
+  },
   room: {
     reservedRCL: {
       0: 1,
@@ -177,9 +182,6 @@ global.config = {
     reviveEnergyCapacity: 1000,
     reviveEnergyAvailable: 1000,
     reviveStorageAvailable: 3000,
-    scoutInterval: 1499,
-    scoutSkipWhenStuck: true, // Useful for novice areas.
-    scout: true, // TODO somehow broken ?? Is it broken ??
     upgraderMinStorage: 0,
     upgraderStorageFactor: 2,
     lastSeenThreshold: 1000000,
@@ -236,6 +238,7 @@ global.config = {
       carry: 5
     },
     otherRoom: {
+      scout: 10,
       harvester: 11,
       defender: 12,
       defendranged: 13,

--- a/src/config.js
+++ b/src/config.js
@@ -160,10 +160,13 @@ global.config = {
   },
 
   scout: {
-    amount: [1,2,3,4,5,6,7,8],   // by RCL
-    intervalBetweenRoomVisit: 500,
-    scoutSkipWhenStuck: true, // Useful for novice areas.
+    amount: [1, 2, 3, 4, 5, 6, 7, 8],   // by RCL
+    intervalBetweenRoomVisits: 500,
+    intervalBetweenHostileVisits: 2500,
+    intervalBetweenBlockedVisits: 1500,
+    maxDistanceAroundTarget: 5,
   },
+
   room: {
     reservedRCL: {
       0: 1,

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -37,34 +37,6 @@ Room.prototype.myHandleRoom = function() {
   return this.executeRoom();
 };
 
-Room.prototype.newScoutTarget = function(creep) {
-  let oldestRoom;
-  let oldestAge = Game.time - config.scout.intervalBetweenRoomVisit;
-  root : for (let deepRooms of this.memory.roomsPatern) {
-    for (let room of deepRooms) {
-      if (!this.memory) {
-        oldestRoom = room;
-        break root;
-      }
-      let scoutSeen = this.memory.scoutSeen;
-      if (scoutSeen) {
-        if (Game.creeps[scoutSeen]) {
-          continue;
-        }
-        delete this.memory.scoutSeen;
-      }
-      if (Memory.rooms[room].lastSeen < oldestAge) {
-        oldestRoom = room;
-        oldestAge = Memory.rooms[room].lastSeen;
-      }
-    }
-  }
-  if (oldestRoom) {
-    return oldestRoom;
-  }
-  return null;
-};
-
 Room.prototype.initRoomsPatern = function() {
   let roomsPatern = [[this.name],[]];
   let n = 0;

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -165,19 +165,9 @@ Room.prototype.handleScout = function() {
   if (this.name === 'sim') {
     return false;
   }
-  let shouldSpawn = (
-    this.exectueEveryTicks(config.room.scoutInterval) &&
-    this.controller.level >= 2 &&
-    this.memory.queue.length === 0 &&
-    config.room.scout
-  );
-  if (shouldSpawn) {
-    let scout_spawn = {
-      role: 'scout'
-    };
-    if (!this.inQueue(scout_spawn)) {
-      this.memory.queue.push(scout_spawn);
-    }
+  let amountNeeded = config.scout.amount[this.controller.level - 1];
+  if (amountNeeded && this.exectueEveryTicks(Math.ceil(1500 / amountNeeded))) {
+    this.checkRoleToSpawn('scout', 1, undefined, undefined, 0, this.name);
   }
 };
 

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -200,42 +200,6 @@ Room.stringToPath = function(string) {
   return path;
 };
 
-/**
-Room.prototype.randomRoomAround = function(exits) { //TODO : move to rooms proto
-  let target;
-  let rooms = exits || Game.map.describeExits(this.name);
-  while (!target) {
-    target = rooms[Math.floor(Math.random() * 4 - 0.01) * 2 + 1];
-  }
-  return target;
-};
-**/
-
-Room.prototype.randomRoomAround = function() {
-  let rooms = Game.map.describeExits(this.name);
-  let age;
-  let roomsRet = [];
-  let totalAge = 0;
-  for (let direction in rooms) {
-    let roomNext = rooms[direction];
-    let roomMem = Memory.rooms[roomNext];
-    if (roomMem && (roomMem.unSafe || (Game.time - roomMem.lastSeen) > 5000)) {
-      continue;
-    }
-    age = (roomMem && (Math.max(Game.time - roomMem.lastSeen, config.scout.intervalBetweenRoomVisit))) || config.scout.intervalBetweenRoomVisit;
-    roomsRet.push({name: roomNext, age: age});
-    totalAge += age;
-  }
-  let random = Math.random() * totalAge;
-  totalAge = 0;
-  for (let room of roomsRet) {
-    totalAge += room.age;
-    if (totalAge <= random) {
-      return room.name;
-    }
-  }
-};
-
 Room.test = function() {
   let original = Memory.rooms.E37N35.routing['pathStart-harvester'].path;
   let string = Room.pathToString(original);

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -165,6 +165,42 @@ Room.stringToPath = function(string) {
   return path;
 };
 
+/**
+Room.prototype.randomRoomAround = function(exits) { //TODO : move to rooms proto
+  let target;
+  let rooms = exits || Game.map.describeExits(this.name);
+  while (!target) {
+    target = rooms[Math.floor(Math.random() * 4 - 0.01) * 2 + 1];
+  }
+  return target;
+};
+**/
+
+Room.prototype.randomRoomAround = function() {
+  let rooms = Game.map.describeExits(this.name);
+  let age;
+  let roomsRet = [];
+  let totalAge = 0;
+  for (let direction in rooms) {
+    let roomNext = rooms[direction];
+    let roomMem = Memory.rooms[roomNext];
+    if (roomMem && (roomMem.unSafe || (Game.time - roomMem.lastSeen) > 5000)) {
+      continue;
+    }
+    age = (roomMem && (Math.max(Game.time - roomMem.lastSeen, config.scout.intervalBetweenRoomVisit))) || config.scout.intervalBetweenRoomVisit;
+    roomsRet.push({name: roomNext, age: age});
+    totalAge += age;
+  }
+  let random = Math.random() * totalAge;
+  totalAge = 0;
+  for (let room of roomsRet) {
+    totalAge += room.age;
+    if (totalAge <= random) {
+      return room.name;
+    }
+  }
+};
+
 Room.test = function() {
   let original = Memory.rooms.E37N35.routing['pathStart-harvester'].path;
   let string = Room.pathToString(original);

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -95,8 +95,11 @@ Room.prototype.randomRoomAround = function(base) {
     if (roomMem && roomMem.tickHostilesSeen && (Game.time - roomMem.tickHostilesSeen) < config.scout.intervalBetweenHostileVisits) {
       continue;
     }
-    age = ((roomMem && (Math.max(Game.time - roomMem.lastSeen, config.scout.intervalBetweenRoomVisits))) || config.scout.intervalBetweenRoomVisits) *
-        (5 - Math.max(Game.map.getRoomLinearDistance(roomNext, base), config.scout.maxDistanceAroundTarget)) / config.scout.maxDistanceAroundTarget;
+    let distance = Math.min(Game.map.getRoomLinearDistance(roomNext, base), config.scout.maxDistanceAroundTarget);
+    age = roomMem ? (Game.rooms[roomNext] ? config.scout.intervalBetweenRoomVisits : Game.time - roomMem.lastSeen) :  config.scout.intervalBetweenRoomVisits;
+    age = Math.ceil(Math.min(age < 10 ? 0 : age, config.scout.intervalBetweenRoomVisits) * (5 - distance) / config.scout.maxDistanceAroundTarget);
+    Memory.rooms[roomNext] = roomMem || {};
+    Memory.rooms[roomNext].lastAge = age;
     roomsRet.push({name: roomNext, age: age});
     totalAge += age;
   }

--- a/src/role_scout.js
+++ b/src/role_scout.js
@@ -54,6 +54,9 @@ roles.scout.action = function(creep) {
   } else if (creep.memory.search) {
     roles.scout.move(creep);
   }
+  if (creep.isStuck()) {
+    roles.scout.unStuckIt(creep);
+  }
 };
 
 const isSafe = function(roomMem) {
@@ -157,10 +160,6 @@ roles.scout.move = function(creep) {
       }
     }
     let returnCode = creep.move(creep.pos.getDirectionTo(search.path[0]));
-  }
-
-  if (creep.isStuck()) {
-    roles.scout.unStuckIt(creep);
   }
 };
 

--- a/src/role_scout.js
+++ b/src/role_scout.js
@@ -171,9 +171,9 @@ roles.scout.unStuckIt = function(creep) {
   if (creep.memory.stuckAmount === 2) {
     creep.memory.moveTo = true;
   } else if (creep.memory.stuckAmount === 4) {
-    delete creep.memory.search.target;
     Memory.rooms[creep.memory.search.target] = Memory.rooms[creep.memory.search.target] || {};
     Memory.rooms[creep.memory.search.target].tickBlockedFlag = Game.time;
+    delete creep.memory.search.target;
   } else if (creep.memory.stuckAmount === 6) {
     delete creep.memory.search;
     creep.memory.stuckAmount = 0;
@@ -183,9 +183,12 @@ roles.scout.unStuckIt = function(creep) {
 
 roles.scout.enterNewRoom = function(creep) {
   creep.room.memory.lastSeen = Game.time;
-  creep.memory.stuckAmount = 0;
   creep.memory.moveTo = false;
   let roomMem = creep.room.memory;
+
+  if (creep.memory.stuckAmount > 4) {
+    creep.memory.stuckAmount = 0;
+  }
 
   let youngerCreepHere = roomMem && roomMem.scoutSeen;
   if (!youngerCreepHere || !Game.creeps[youngerCreepHere] || Game.creeps[youngerCreepHere].ticksToLive < creep.ticksToLive) {

--- a/src/role_scout.js
+++ b/src/role_scout.js
@@ -10,58 +10,88 @@ roles.scout = {};
 roles.scout.settings = {
   layoutString: 'M',
   amount: [1],
-  maxLayoutAmount: 1
+  maxLayoutAmount: 1,
+};
+
+roles.scout.died = function(name, memory) {
+  const baseName = memory.base;
+  Game.rooms[baseName].checkRoleToSpawn('scout', 0, undefined, undefined, 0, baseName);
+  delete Memory.creeps[name];
 };
 
 roles.scout.execute = function(creep) {
-  if (creep.memory.skip === undefined) {
-    creep.memory.skip = [];
-  }
-
   if (!creep.memory.notifyDisabled) {
     creep.notifyWhenAttacked(false);
     creep.memory.notifyDisabled = true;
   }
+};
+roles.scout.action = function(creep) {
+  if (!creep.memory.search) {
+    creep.say('init');
+    roles.scout.initSearch(creep);
+  }
+  if (creep.room.name === creep.memory.search.target || !creep.memory.search.target) {
+    creep.say('switch');
+    creep.memory.search.target = creep.room.randomRoomAround(creep.memory.search.startRoom || creep.memory.base);
 
-  return roles.scout.search(creep);
+    if (creep.memory.search.target) {
+      Memory.rooms[creep.memory.search.target].lastSeen = Game.time;
+    } else {
+      if (creep.pos.roomName === creep.memory.search.startRoom) {
+        delete creep.memory.search.target;
+      } else {
+        creep.memory.search.target = creep.memory.search.startRoom || creep.memory.base;
+      }
+    }
+  }
+  if (creep.memory.last && creep.memory.last.pos1 && creep.room.name !== creep.memory.last.pos1.roomName) {
+    roles.scout.enterNewRoom(creep);
+  }
+  let targetPos = new RoomPosition(25, 25, creep.memory.search.target);
+  roles.scout.move(creep, targetPos);
 };
 
-roles.scout.unStuckIt = function(creep, targetPos) {
-  if (creep.isStuck()) {
-    let returnCode = creep.moveTo(targetPos, {
-      ignoreCreeps: false,
-      costCallback: creep.room.getCostMatrixCallback()
-    });
+const isSafe = function(roomMem) {
+  if (roomMem && (roomMem.state === 'Occupied' ||
+    (roomMem.tickBlockedFlag && (Game.time - roomMem.tickBlockedFlag) < config.scout.intervalBetweenBlockedVisits) ||
+    (roomMem.tickHostilesSeen  && (Game.time - roomMem.tickHostilesSeen) < config.scout.intervalBetweenHostileVisits))) {
+    return false;
+  }
+  return true;
+};
 
-    if (returnCode != OK) {
-      creep.moveRandom();
-    }
-    creep.log('Scout Stuck at :' + JSON.stringify(creep.memory.last)); // + ' ' + JSON.stringify(creep.isStuck()));
+const needVisit = function(roomMem) {
+  if (!roomMem || ((!roomMem.scoutSeen || !Game.creeps[roomMem.scoutSeen]) &&
+    ((Game.time - roomMem.lastSeen) > config.scout.intervalBetweenRoomVisits))) {
     return true;
   }
+  return false;
 };
 
+roles.scout.initSearch = function(creep) {
+  creep.memory.search = {};
 
-
-roles.scout.goFurther = function(creep) {
-  creep.memory.search.levels[creep.memory.search.level + 1] = [];
-  let target = creep.room.lookAround(creep.memory.search.level + 1, true);
-  if (target) {
-    if (!Memory.rooms[target]) {
-      Memory.rooms[target] = {};
+  let roomsPatern = Memory.rooms[creep.memory.base].roomsPatern;
+  let deep = 1;
+  while (roomsPatern[deep]) {
+    for (let roomName of roomsPatern[deep]) {
+      const roomMem = Memory.rooms[roomName].lastSeen;
+      if (isSafe(roomMem) && needVisit(roomMem)) {
+        creep.memory.search.target = roomName;
+        creep.memory.search.startRoom = roomName;
+        return true;
+      }
     }
-    Memory.rooms[target].scoutSeen = creep.name;
+    deep++;
   }
-
-  if (creep.memory.search.levels[creep.memory.search.level + 1].length === 0) {
-    return false;
-  } // debug line
-  creep.memory.search.level++;
+  return false;
 };
 
-roles.scout.move = function(creep, targetPos) {
+roles.scout.move = function(creep) {
+  let targetPos = new RoomPosition(25, 25, creep.memory.search.target);
   let costMatrix = function(roomName) {
-    if (!Memory.rooms[roomName] || (Memory.rooms[roomName].lastSeen < (Game.time - 15))) {
+    let roomMem = Memory.rooms[roomName];
+    if (isSafe(roomMem)) {
       return creep.room.getCostMatrixCallback(targetPos, true, false, true);
     }
     return false;
@@ -72,7 +102,7 @@ roles.scout.move = function(creep, targetPos) {
       pos: targetPos,
       range: 20
     }, {
-      roomCallback: costMatrix
+      roomCallback: costMatrix,
     }
   );
 
@@ -80,104 +110,55 @@ roles.scout.move = function(creep, targetPos) {
     visualizer.showSearch(search);
   }
 
-  if (search.path.length === 0 || (creep.inBase() && creep.room.memory.misplacedSpawn)) {
-    if (creep.isStuck() && creep.pos.isBorder()) {
-      creep.say('imstuck at the border', true);
-      if (config.scout.scoutSkipWhenStuck) {
-        creep.say('skipping', true);
-        creep.memory.scoutSkip = true;
-        delete creep.memory.last; // Delete to reset stuckness.
+  if (search.path.length === 0) {
+    creep.say('?');
+    if (creep.isStuck()) {
+      let search = PathFinder.search(
+          creep.pos, {
+            pos: targetPos,
+            range: 20
+          }, {
+            ignoreCreeps: true,
+            roomCallback: costMatrix,
+            maxOps: 10000,
+          }
+        );
+
+      if (search.path.length === 0) {
+        Memory.rooms[creep.memory.search.target] = Memory.rooms[creep.memory.search.target] || {};
+        Memory.rooms[creep.memory.search.target].tickBlockedFlag = Game.time;
+        creep.memory.search = {};
+        return false;
       }
     }
-
-    let returnCode = creep.moveTo(targetPos, {
-      ignoreCreeps: true,
-      costCallback: creep.room.getCostMatrixCallback()
-    });
-
-    return true;
   }
-  creep.say('Hi -> ' + creep.memory.search.target, true);
+  creep.say(creep.memory.search.target);
   let returnCode = creep.move(creep.pos.getDirectionTo(search.path[0]));
-};
-roles.scout.shouldSwitch = function(creep) {
-  if (creep.memory.scoutSkip) {
-    creep.memory.skip.push(creep.memory.search.target);
-    delete creep.memory.scoutSkip;
-    return true;
-  } else if (creep.room.name === creep.memory.search.target) {
-    creep.memory.search.seen.push(creep.room.name);
-    return true;
-  }
-};
-/**
-roles.scout.switchTarget = function(creep) {
-  let target = creep.room.randomRoomAround(true);
-  if (!target) {
-    target = Game.rooms[creep.memory.base].setNewTarget();
-    if (!target) {
-      target = creep.room.oldestRoomAround(true);
+  if (creep.isStuck()) {
+    creep.memory.stuckAmount = creep.memory.stuckAmount ? creep.memory.stuckAmount + 1 : 1;
+    delete creep.memory.search.target;
+    if (creep.memory.stuckAmount >= 5) {
+      delete creep.memory.search;
+      creep.memory.stuckAmount = 0;
     }
+    delete creep.memory.last;
+    creep.moveTo(targetPos);
   }
 };
-**/
-roles.scout.initSearch = function(creep) {
-  if (!creep.memory.search || !creep.memory.search.target) {
-    creep.memory.search = {seen: []};
-    let roomsPatern = Memory.rooms[creep.memory.base].roomsPatern;
-    let deep = 1;
-    while(roomsPatern[deep]){
 
-    for (let roomName of roomsPatern[deep]) {
-
-        let roomMem = Memory.rooms[roomName];
-        if (!roomMem ||
-           ((!roomMem.scoutSeen || !Game.creeps[roomMem.scoutSeen]) &&
-           (!roomMem.unSafe || (Game.time - roomMem.lastSeen) > 5000))) {
-          creep.memory.search.target = roomName;
-          return true;
-        }
-
-    }
-    deep++
-    }
-    return false;
+roles.scout.enterNewRoom = function(creep) {
+  let roomMem = creep.room.memory;
+  let youngerCreepHere = creep.room.memory.scoutSeen;
+  if (!youngerCreepHere || !Game.creeps[youngerCreepHere] || Game.creeps[youngerCreepHere].ticksToLive < creep.ticksToLive) {
+    creep.room.memory.scoutSeen = creep.name;
   }
-  return true;
-};
-
-roles.scout.search = function(creep) {
-
-  if (!roles.scout.initSearch(creep) || roles.scout.shouldSwitch(creep)) {
-    creep.memory.search.target = creep.room.randomRoomAround();
-  }
-  let emojis = ['🌴', '💪', '🍺', '🎵', '👀', '🍖'];
-  creep.say(emojis[Game.time % 6]);
-
-  if (!creep.memory.search.target) {
-    creep.log('Suiciding: ' + JSON.stringify(creep.memory.search));
-    //creep.suicide();
-    return true;
-  }
-
-  let targetPos = new RoomPosition(25, 25, creep.memory.search.target);
 
   if (creep.room.getEnemys().length) {
     creep.say('Afraid', true);
-    creep.room.memory.unSafe = true;
-    delete creep.memory.search.target;
+    creep.room.memory.tickHostilesSeen = Game.time;
     return false;
   }
-  if (creep.memory.last && creep.memory.last.pos3 && creep.room.name !== creep.memory.last.pos3.roomName) {
-    creep.memory.search.target = creep.room.randomRoomAround();
-    let roomMem = creep.room.memory;
-    let youngerCreepHere = creep.room.memory.scoutSeen;
-    if (!youngerCreepHere || !Game.creeps[youngerCreepHere] || Game.creeps[youngerCreepHere].ticksToLive < creep.ticksToLive) {
-      creep.room.memory.scoutSeen = creep.name;
-    }
-    creep.moveTo(25, 25, {maxOps: 100});
-    return true;
-  }
-  roles.scout.unStuckIt(creep, targetPos);
-  roles.scout.move(creep, targetPos);
+
+  creep.moveTo(25, 25, {maxOps: 100});
+  return true;
 };


### PR DESCRIPTION
-scouts now prioritize not recently seen rooms  …
-scout no more stuck on borders
-increased number of scouts with RCL

TODO : move levels from creeps memory to room memory and iterate along it at scout spawn before create his own levels which will be lighter

example of behavior around https://screeps.com/a/#!/room/shard1/W33N34 if nothing bug. ^^ Looks well right now.
