### PR TITLE
Add break out of conditional for misplaced spawn

### DIFF
--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -75,6 +75,7 @@ roles.carry.handleMisplacedSpawn = function(creep) {
         ignoreCreeps: true,
       });
       creep.transfer(structure, RESOURCE_ENERGY);
+      return true;
     } else {
       const targetId = creep.memory.routing.targetId;
 


### PR DESCRIPTION
## What

Updated the `roles.carry.handleMisplacedSpawn` to skip the better position.

## Why

Placing an initial spawn in an initially not optimal spot causes traffic jams and issues. This will temporarily skip the code which delays re-positioning the room.