### PR TITLE
screeps.com fixes

### DIFF
--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -33,6 +33,9 @@ Creep.prototype.checkStorageMinerals = function() {
 };
 
 Creep.prototype.checkEnergyThreshold = function(structure, value, below = false) {
+  if (!this.room[structure]) {
+    return true;
+  }
   if (below) {
     return this.room[structure].store.energy < value;
   }

--- a/src/role_planer.js
+++ b/src/role_planer.js
@@ -19,7 +19,7 @@ roles.planer.action = function(creep) {
   const methods = [Creep.getEnergy];
 
   methods.push(Creep.constructTask);
-  methods.push(Creep.buildRoads);
+  // methods.push(Creep.buildRoads);
   if (creep.room.memory.misplacedSpawn) {
     methods.push(Creep.transferEnergy);
     methods.push(Creep.repairStructure);


### PR DESCRIPTION
Roads are mainly build due to `harverster` and `carry` creeps, no need to execute it in planer.

Catch exception for mineral creep.