### PR TITLE
[WIP] improve carry recycling

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -142,10 +142,13 @@ global.config = {
       1800: [8, 15], // RCL 5
       2300: [11, 21], // RCL 6
     },
+    transferToCarry: false,
+    // limit carry spawn rate when RCL < 4
+    minSpawnRate: 50,
     // when ticksToLive > recycleThreshold, reuse carry
     recycleThreshold: 200,
-    transferToCarry: false,
-    minSpawnRate: 50,
+    // keep at least one carry for a target
+    ensureOne: true,
     // Percentage should increase from base to target room. Decrease may cause stack on border
     carryPercentageBase: 0.1,
     carryPercentageHighway: 0.2,

--- a/src/config.js
+++ b/src/config.js
@@ -142,6 +142,9 @@ global.config = {
       1800: [8, 15], // RCL 5
       2300: [11, 21], // RCL 6
     },
+    // when ticksToLive > recycleThreshold, reuse carry
+    recycleThreshold: 200,
+    transferToCarry: false,
     minSpawnRate: 50,
     // Percentage should increase from base to target room. Decrease may cause stack on border
     carryPercentageBase: 0.1,
@@ -243,9 +246,9 @@ global.config = {
       defender: 12,
       defendranged: 13,
       nextroomer: 15,
-      carry: 17,
+      reserver: 17,
       sourcer: 18,
-      reserver: 19,
+      carry: 19,
     },
   },
 };

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -63,7 +63,7 @@ Creep.prototype.handle = function() {
     return;
   }
 
-  if (this.memory.recycle && this.memory.moveToSpawn) {
+  if (this.memory.recycle) {
     Creep.recycleCreep(this);
     return;
   }

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -63,7 +63,7 @@ Creep.prototype.handle = function() {
     return;
   }
 
-  if (this.memory.recycle) {
+  if (this.memory.recycle && this.memory.moveToSpawn) {
     Creep.recycleCreep(this);
     return;
   }

--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -67,18 +67,13 @@ Creep.prototype.spawnCarry = function() {
     Math.sqrt(carryCapacity / Math.max(resourceAtPosition, carryCapacity));
 
   if (resourceAtPosition > carryCapacity) {
-    baseRoom.checkRoleToSpawn('carry', 0, this.memory.routing.targetId,
-      this.memory.routing.targetRoom, undefined, undefined, {
-        checkRecycle: true,
-      });
+    baseRoom.checkRoleToSpawn('carry', 0, this.memory.routing.targetId, this.memory.routing.targetRoom);
   }
 
-  // low minSpawnRate helps carry recycling
-  let minSpawnRate = 10;
-
-  // higher minSpawnRate when RCL < 4
+  // limit carry spawn rate when RCL < 4
   if (baseRoom.controller.level < 4) {
-    minSpawnRate = config.carry.minSpawnRate;
+    this.memory.wait = Math.max(waitTime, config.carry.minSpawnRate);
+  } else {
+    this.memory.wait = waitTime;
   }
-  this.memory.wait = Math.max(waitTime, minSpawnRate);
 };

--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -43,13 +43,13 @@ Creep.prototype.spawnCarry = function() {
     return false;
   }
 
+  const baseRoom = Game.rooms[this.memory.base];
+
   const foundKey = Object.keys(config.carry.sizes).reverse()
-    .find((key) => (key <= Game.rooms[this.memory.base].energyCapacityAvailable));
+    .find((key) => (key <= baseRoom.energyCapacityAvailable));
   const carryCapacity = config.carry.sizes[foundKey][1] * CARRY_CAPACITY;
 
   const workParts = this.body.filter((part) => part.type === WORK).length;
-
-  const waitTime = carryCapacity / (HARVEST_POWER * workParts);
 
   let resourceAtPosition = 0;
   const resources = this.pos.lookFor(LOOK_RESOURCES);
@@ -63,15 +63,22 @@ Creep.prototype.spawnCarry = function() {
     resourceAtPosition += _.sum(container.store);
   }
 
+  const waitTime = carryCapacity / (HARVEST_POWER * workParts) *
+    Math.sqrt(carryCapacity / Math.max(resourceAtPosition, carryCapacity));
+
   if (resourceAtPosition > carryCapacity) {
-    Game.rooms[this.memory.base].checkRoleToSpawn('carry', 0, this.memory.routing.targetId, this.memory.routing.targetRoom);
-  } else if (resourceAtPosition <= HARVEST_POWER * workParts) {
-    const nearCarries = this.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 2, 'memory.role', ['carry'], false, {
-      filter: (creep) => creep.memory.routing.targetId === this.memory.routing.targetId,
-    });
-    if (nearCarries.length > 1) {
-      nearCarries[0].memory.recycle = true;
-    }
+    baseRoom.checkRoleToSpawn('carry', 0, this.memory.routing.targetId,
+      this.memory.routing.targetRoom, undefined, undefined, {
+        checkRecycle: true,
+      });
   }
-  this.memory.wait = Math.max(waitTime, config.carry.minSpawnRate);
+
+  // low minSpawnRate helps carry recycling
+  let minSpawnRate = 10;
+
+  // higher minSpawnRate when RCL < 4
+  if (baseRoom.controller.level < 4) {
+    minSpawnRate = config.carry.minSpawnRate;
+  }
+  this.memory.wait = Math.max(waitTime, minSpawnRate);
 };

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -297,6 +297,9 @@ const checkCreepForTransfer = function(creep) {
   if (Game.creeps[creep.name].memory.role === 'powertransporter') {
     return false;
   }
+  if (!config.carry.transferToCarry && Game.creeps[creep.name].memory.role === 'carry') {
+    return false;
+  }
   if (creep.carry.energy === creep.carryCapacity) {
     return false;
   }

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -29,12 +29,8 @@ Creep.prototype.harvesterBeforeStorage = function() {
   return true;
 };
 
-Creep.prototype.checkEnergyTransfer = function(otherCreep) {
+Creep.prototype.checkEnergyTransfer = function(offset = 0) {
   // TODO duplicate from role_carry, extract to method
-  let offset = 0;
-  if (otherCreep) {
-    offset = otherCreep.carry.energy;
-  }
 
   // define minimum carryPercentage to move back to storage
   let carryPercentage = config.carry.carryPercentageHighway;
@@ -65,7 +61,7 @@ Creep.prototype.findCreepWhichCanTransfer = function(creeps) {
       if (otherCreep.checkHelperNoTransfer(this)) {
         continue;
       }
-      return this.checkEnergyTransfer(otherCreep);
+      return this.checkEnergyTransfer(otherCreep.carry[RESOURCE_ENERGY]);
     }
     continue;
   }
@@ -79,10 +75,7 @@ Creep.prototype.checkForTransfer = function(direction) {
 
   const adjacentPos = this.pos.getAdjacentPosition(direction);
 
-  if (adjacentPos.x < 0 || adjacentPos.y < 0) {
-    return false;
-  }
-  if (adjacentPos.x > 49 || adjacentPos.y > 49) {
+  if (!adjacentPos.isValid()) {
     return false;
   }
 
@@ -106,7 +99,7 @@ Creep.prototype.pickupWhileMoving = function(reverse) {
   if (resources.length > 0) {
     const resource = resources[0];
     const amount = this.pickupOrWithdrawFromSourcer(resource);
-    return _.sum(this.carry) + amount > 0.5 * this.carryCapacity;
+    return this.checkEnergyTransfer(amount);
   }
 
   if (this.room.name === this.memory.routing.targetRoom) {
@@ -118,7 +111,7 @@ Creep.prototype.pickupWhileMoving = function(reverse) {
       }
       if (container.store[RESOURCE_ENERGY]) {
         this.withdraw(container, RESOURCE_ENERGY);
-        return container.store[RESOURCE_ENERGY] > 9;
+        return this.checkEnergyTransfer(container.store[RESOURCE_ENERGY]);
       }
     }
   }

--- a/src/prototype_creep_routing.js
+++ b/src/prototype_creep_routing.js
@@ -272,6 +272,10 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, action, 
         if (this.memory.killPrevious) {
           this.killPrevious();
         }
+        if (this.memory.checkRecycle && this.isStuck() && !this.memory.routing.reverse) {
+          // recycle carry
+          this.memory.recycle = true;
+        }
       }
       if (pathPos === path.length - 1 && !this.memory.routing.reverse) {
         // this.log('creep_routing.followPath reached: ' + pathPos + '

--- a/src/prototype_creep_routing.js
+++ b/src/prototype_creep_routing.js
@@ -163,8 +163,15 @@ Creep.prototype.followPath = function(action) {
     return action(this);
   }
   const prepareData = this.moveByPathPrepare(route, routePos, 'pathStart', this.memory.routing.targetId);
+  let routeLength;
+  let pathLength;
+  if (prepareData.pathPos) {
+    this.memory.routing.pathPos = prepareData.pathPos;
+    routeLength = route.length;
+    pathLength = prepareData.path.length;
+  }
   if (prepareData.unit.preMove) {
-    if (prepareData.unit.preMove(this, prepareData.directions)) {
+    if (prepareData.unit.preMove(this, prepareData.directions, routeLength, pathLength)) {
       return true;
     }
   }
@@ -206,7 +213,6 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, action, 
 
   if (pathPos < 0) {
     // this.say('R:pos -1');
-    this.memory.routing.pathPos = pathPos;
     if (path.length === 0) {
       this.log('config_creep_routing.followPath no pos: ' + JSON.stringify(path));
       return false;
@@ -271,10 +277,6 @@ Creep.prototype.moveByPathMy = function(route, routePos, start, target, action, 
       if (pathPos === path.length - 2) {
         if (this.memory.killPrevious) {
           this.killPrevious();
-        }
-        if (this.memory.checkRecycle && this.isStuck() && !this.memory.routing.reverse) {
-          // recycle carry
-          this.memory.recycle = true;
         }
       }
       if (pathPos === path.length - 1 && !this.memory.routing.reverse) {

--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -59,7 +59,7 @@ roles.carry.reset = function(creep) {
 roles.carry.ensureOne = function(creep) {
   if (config.carry.ensureOne) {
     const nearCarries = creep.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 1, 'memory.role', ['carry'], false, {
-      filter: (otherCreep) => otherCreep.memory.routing.targetId === creep.memory.routing.targetId,
+      filter: (otherCreep) => !otherCreep.resetTarget && otherCreep.memory.routing.targetId === creep.memory.routing.targetId,
     });
     if (nearCarries.length < 2) {
       creep.memory.resetTarget = false;


### PR DESCRIPTION
The main point of this commit is improving energy harvest efficiency.

1. Improved the way to check extra carries.  Carries will be recycled if they are waiting for sourcer.
2. Before recycling carries with a spawn, check spawn queue and assign a new target to carry.
3. Sourcers calculate spawn rate depending on `resourceAtPostion`.
4. Added an option to switch on/off energy transfer between carries.  It's turned off by default.
5. Modified spawn priority for reserver and carry.

With this improvement, carries will work more efficiently.  Tested on the official server:
![2017-09-12 10 12 47](https://user-images.githubusercontent.com/20679177/30330411-95791c7e-9807-11e7-88ca-9bb27d7f4727.png)
Stored about 900k energy in storage before upgrading to RCL6. (five sources in extern room)