### PR TITLE
Fixes Exeception TypeError: if Memory.squads is undefined

### DIFF
--- a/src/config_brain_squadmanager.js
+++ b/src/config_brain_squadmanager.js
@@ -80,6 +80,14 @@ brain.isFriend = function(name) {
 };
 
 brain.handleSquadmanager = function() {
+  if (!Memory.squads) {
+    Memory.squads = {};
+  }
+
+  const squads = Object.keys(Memory.squads);
+  if (squads.length === 0) {
+    return false;
+  }
   for (const squadIndex of Object.keys(Memory.squads)) {
     const squad = Memory.squads[squadIndex];
     if (!squad.siege || Object.keys(squad.siege).length === 0) {


### PR DESCRIPTION
Exeception TypeError: Cannot convert undefined or null to object
Object.keys(Memory.squads) => Object.keys(undefined)