### PR TITLE
Fixed carry stuck at `pathStart` when storage is full

### DIFF
--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -360,7 +360,9 @@ const filterTransferrables = function(creep, object) {
     return false;
   }
 
-  if (object.structureType !== STRUCTURE_STORAGE && object.energy === object.energyCapacity) {
+  if (object.structureType === STRUCTURE_STORAGE ?
+    _.sum(object.store) + _.sum(creep.carry) > object.storeCapacity :
+    object.energy === object.energyCapacity) {
     return false;
   }
 
@@ -409,6 +411,12 @@ Creep.prototype.transferToStructures = function() {
       }
       transferred = this.transferAllResources(item.structure);
     }
+  }
+  if (transferred) {
+    return {
+      moreStructures: false,
+      transferred: transferred,
+    };
   }
   return false;
 };

--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -143,18 +143,20 @@ roles.carry.preMove = function(creep, directions) {
           return true;
         }
         reverse = creep.carry.energy - transferred.transferred > 0;
-      } else if (creep.memory.routing.pathPos === 0 && !(creep.room.storage && creep.room.storage.my && creep.room.storage.isActive())) {
+      } else if (creep.memory.routing.pathPos === 0) {
         creep.drop(RESOURCE_ENERGY);
         reverse = false;
-
-        let resourceAtPosition = 0;
-        const resources = creep.pos.lookFor(LOOK_RESOURCES);
-        for (const resource of resources) {
-          resourceAtPosition += resource.amount;
+        const storage = creep.room.storage;
+        if (!(storage && storage.my && storage.isActive())) {
+          let resourceAtPosition = 0;
+          const resources = creep.pos.lookFor(LOOK_RESOURCES);
+          for (const resource of resources) {
+            resourceAtPosition += resource.amount;
+          }
+          let amount = creep.room.getHarvesterAmount();
+          amount += Math.floor(resourceAtPosition / config.carry.callHarvesterPerResources);
+          creep.room.checkRoleToSpawn('harvester', amount, 'harvester');
         }
-        let amount = creep.room.getHarvesterAmount();
-        amount += Math.floor(resourceAtPosition / config.carry.callHarvesterPerResources);
-        creep.room.checkRoleToSpawn('harvester', amount, 'harvester');
       }
     }
     if (directions.backwardDirection && directions.backwardDirection !== null) {


### PR DESCRIPTION
Carry will drop resources at `pathStart` if storage is full

Updated:
Fixed `transferToStructures`