### PR TITLE
scoutnextroom will say their goalRoom instead of undefined

### DIFF
--- a/src/role_scoutnextroom.js
+++ b/src/role_scoutnextroom.js
@@ -198,6 +198,6 @@ roles.scoutnextroom.execute = function(creep) {
     }
     return true;
   }
-  creep.say(creep.memory.target.goalRoom);
+  creep.say(creep.memory.goalRoom);
   creep.move(creep.pos.getDirectionTo(search.path[0]));
 };


### PR DESCRIPTION
this looks like a simple typo? memory.target is a RoomPosition, I think. probably just meant to say the goalRoom set when the target is set.