### PR TITLE
Better creep position visualization, letters instead of numbers

### DIFF
--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -105,7 +105,11 @@ if (config.visualizer.enabled) {
                 let text = positionName.substr(0, 1);
                 const target = Game.getObjectById(positionName);
                 if (target) {
-                  text = target.structureType.substr(0, 1);
+                  if (target.structureType) {
+                    text = target.structureType.substr(0, 1);
+                  } else {
+                    text = 's'; // source
+                  }
                 }
                 this.drawPosition(rv, creeps[positionName], text, 'yellow');
               } else {

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -102,10 +102,14 @@ if (config.visualizer.enabled) {
           for (const positionName of Object.keys(creeps)) {
             if (creeps[positionName]) {
               if (creeps[positionName].x || creeps[positionName].y) {
-                const text = positionName.substr(0, 1);
+                let text = positionName.substr(0, 1);
+                const target = Game.getObjectById(positionName);
+                if (target) {
+                  text = target.structureType.substr(0, 1);
+                }
                 this.drawPosition(rv, creeps[positionName], text, 'yellow');
               } else {
-                const text = positionName.substr(0, 1);
+                const text = positionName.substr(0, 1); // always 't'
                 for (const towerfiller of creeps[positionName]) {
                   this.drawPosition(rv, towerfiller, text, 'yellow');
                 }


### PR DESCRIPTION
This changes the yellow text visualization to the first letter of the creep's target, rather than a number that's almost always '5'.