### PR TITLE
move pathStart from first pos near storage to best

### DIFF
--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -46,7 +46,7 @@ Room.prototype.initSetStorageAndPathStart = function() {
   costMatrix.set(storagePos.x, storagePos.y, config.layout.structureAvoid);
   this.setMemoryCostMatrix(costMatrix);
 
-  this.memory.position.creep.pathStart = storagePos.getFirstNearPosition();
+  this.memory.position.creep.pathStart = storagePos.getBestNearPosition();
 
   const route = [{
     room: this.name,


### PR DESCRIPTION
pathStart was previously placed at the first available (in direction order) location adjacent to the storage. let's switch that to the location with the most adjacent open spaces to avoid some traffic jams.