### PR TITLE
check source for truthiness, not just !== null

### DIFF
--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -83,7 +83,7 @@ roles.carry.handleMisplacedSpawn = function(creep) {
 
       const source = creep.room.memory.position.creep[targetId];
       // TODO better the position from the room memory
-      if (source !== null) {
+      if (source) {
         const sourcePos = new RoomPosition(source.x, source.y, source.roomName);
         creep.moveTo(sourcePos, {
           ignoreCreeps: true,


### PR DESCRIPTION
```
1963970 W46S8  carry-6969           [room W46S8 pos 6,21] Executing creep role failed: W46S8 carry-6969 59c5ee1d246307774f52dc01 {"x":6,"y":21,"roomName":"W46S8"} TypeError: Cannot read property 'x' of undefined
TypeError: Cannot read property 'x' of undefined
    at Object.roles.carry.handleMisplacedSpawn (role_carry:87:50)
```

This might not be the best fix, but it handles null and undefined instead of just null.