### PR TITLE
[WIP] sourcer near storage deposits directly, no carry

### DIFF
--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -14,8 +14,17 @@ Creep.prototype.handleSourcer = function() {
 
   this.buildContainer();
 
-  if (!this.room.controller || !this.room.controller.my || this.room.controller.level >= 2) {
-    this.spawnCarry();
+  const nearStorage = this.room.storage && this.pos.isNearTo(this.room.storage);
+
+  if (nearStorage) {
+    const workParts = this.body.filter((part) => part.type === WORK).length;
+    if (_.sum(this.carry) > this.carryCapacity - workParts * 2) {
+      this.transfer(this.room.storage, RESOURCE_ENERGY);
+    }
+  } else {
+    if (!this.room.controller || !this.room.controller.my || this.room.controller.level >= 2) {
+      this.spawnCarry();
+    }
   }
 
   if (this.inBase()) {


### PR DESCRIPTION
The goal here is for a sourcer adjacent to the storage to deposit energy directly to the storage, without needing a carry. This is especially important if the carry would insist on standing in a spot that causes a traffic jam.

[WIP] pending more testing and possibly more improvements.