### PR TITLE
carry in misplacedSpawn picks up dropped energy at sourcer then bails

### DIFF
--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -88,9 +88,13 @@ roles.carry.handleMisplacedSpawn = function(creep) {
         creep.moveTo(sourcePos, {
           ignoreCreeps: true,
         });
-        if (creep.pos.getRangeTo(sourcePos) > 1) {
-          return true;
+        if (creep.pos.getRangeTo(sourcePos) <= 1) {
+          const target = creep.room.lookForAt(LOOK_RESOURCES, sourcePos)[0];
+          if (target) {
+            creep.pickup(target);
+          }
         }
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
Previously a carry operating in a misplacedSpawn room would seek out the sourcer then let all its other role code handle picking up energy, path reversal, etc. This code replaces that with a much more straightforward "pick up dropped energy, then bail out". May need to be expanded on if a link or container could still be in play at this point?