### PR TITLE
only update memory.last when fatigue === 0

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -133,15 +133,17 @@ Creep.prototype.handle = function() {
     this.log(message);
     Game.notify(message, 30);
   } finally {
-    if (this.memory.last === undefined) {
-      this.memory.last = {};
+    if (this.fatigue === 0) {
+      if (this.memory.last === undefined) {
+        this.memory.last = {};
+      }
+      const last = this.memory.last;
+      this.memory.last = {
+        pos1: this.pos,
+        pos2: last.pos1,
+        pos3: last.pos2,
+      };
     }
-    const last = this.memory.last;
-    this.memory.last = {
-      pos1: this.pos,
-      pos2: last.pos1,
-      pos3: last.pos2,
-    };
   }
 };
 


### PR DESCRIPTION
A creep with low MOVE or walking through swamp isn't stuck just because it's been sitting still for three ticks. It's stuck if it's sitting still for three ticks after its fatigue reaches zero.