### PR TITLE
move visuals summary to dynamic location

### DIFF
--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -108,6 +108,7 @@ Room.prototype.setFillerArea = function(storagePos, route) {
 Room.prototype.updatePosition = function() {
   this.checkCache();
   delete this.memory.routing;
+  delete this.memory.summaryCenter;
 
   const costMatrixBase = this.getCostMatrix();
   this.setMemoryCostMatrix(costMatrixBase);
@@ -157,6 +158,25 @@ Room.prototype.updatePosition = function() {
     }
     this.setFillerArea(startPos.storagePos, startPos.route);
   }
+
+  // find the most remote position to place the room summary visual
+  let bestPosition = null;
+  let bestScore = 0;
+  const reservedPositions = this.getPositions();
+  for (let y = 10; y <= 40; y += 10) {
+    for (let x = 10; x <= 40; x += 10) {
+      let score = 0;
+      const pos = new RoomPosition(x, y, this.name);
+      for (const pos2 of reservedPositions) {
+        score += pos.getRangeTo(pos2);
+      }
+      if (score > bestScore) {
+        bestScore = score;
+        bestPosition = pos;
+      }
+    }
+  }
+  this.memory.summaryCenter = {x: bestPosition.x, y: bestPosition.y};
 };
 
 Room.prototype.setPosition = function(type, pos, value, positionType = 'structure') {

--- a/src/prototype_room_memory.js
+++ b/src/prototype_room_memory.js
@@ -198,3 +198,39 @@ Room.prototype.setMemoryPath = function(name, path, fixed) {
     this.memory.routing[name] = memoryData;
   }
 };
+
+/**
+ * Returns a list of some/all reserved routing positions in the room
+ *
+ * @param {Function} filter - optional function used to filter positions
+ * @return {Array} all reserved positions
+ */
+Room.prototype.getPositions = function(filter) {
+  if (!this.memory.position) {
+    return [];
+  }
+
+  const positions = [];
+  for (const creepId of Object.keys(this.memory.position.creep)) {
+    const pos = this.memory.position.creep[creepId];
+    if (!pos) {
+      continue;
+    }
+    if (!filter || filter(pos)) {
+      positions.push(pos);
+    }
+  }
+  for (const structureId of Object.keys(this.memory.position.structure)) {
+    const poss = this.memory.position.structure[structureId];
+    for (const pos of poss) {
+      if (!pos) {
+        continue;
+      }
+      if (!filter || filter(pos)) {
+        positions.push(pos);
+      }
+    }
+  }
+
+  return positions;
+};

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -272,9 +272,17 @@ global.visualizer.myRoomDatasDraw = function(roomName) {
       Highter queue: ${highterQueue.roomName}:${-highterQueue.length}
       =========================`;
     const lines = output.split('\n');
-    let l = 0;
-    for (l; l < lines.length; l++) {
-      room.visual.text(lines[l], 25, 25 + (l * (fontSize - 0.05)), {font: fontSize});
+    let summaryCenterX = 25;
+    let summaryTopLineY = 25;
+    if (Memory.rooms[roomName].summaryCenter) {
+      summaryCenterX = Math.min(Math.max(Memory.rooms[roomName].summaryCenter.x, 5), 44);
+      const summaryHeight = lines.length * (fontSize - 0.05);
+      summaryTopLineY = Memory.rooms[roomName].summaryCenter.y - summaryHeight / 2 + (fontSize - 0.05);
+      summaryTopLineY = Math.min(Math.max(summaryTopLineY, 1), 49 - summaryHeight + (fontSize - 0.05));
+    }
+
+    for (let l = 0; l < lines.length; l++) {
+      room.visual.text(lines[l], summaryCenterX, summaryTopLineY + (l * (fontSize - 0.05)), {font: fontSize});
     }
   }
 };


### PR DESCRIPTION
Currently the room.memory.summaryCenter has to be set manually. I plan to add a function to room.updatePosition() that keeps track of the emptiest part of the room, then moves the summary there.