### PR TITLE
carry stops before standing on sourcer position

### DIFF
--- a/src/role_carry.js
+++ b/src/role_carry.js
@@ -85,10 +85,10 @@ roles.carry.handleMisplacedSpawn = function(creep) {
       // TODO better the position from the room memory
       if (source !== null) {
         const sourcePos = new RoomPosition(source.x, source.y, source.roomName);
-        creep.moveTo(sourcePos, {
-          ignoreCreeps: true,
-        });
         if (creep.pos.getRangeTo(sourcePos) > 1) {
+          creep.moveTo(sourcePos, {
+            ignoreCreeps: true,
+          });
           return true;
         }
       }


### PR DESCRIPTION
Previously, if a carry was going to get energy from a sourcer, but the sourcer was AWOL, then the carry would stand in the sourcer's spot and block the sourcer from getting to work.