### PR TITLE
don't skip ticks if tickLimit is unusually high (private servers?)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ if (config.profiler.enabled) {
 }
 
 const main = function() {
-  if (Game.cpu.bucket < 2 * Game.cpu.tickLimit) {
+  if (Game.cpu.bucket < 2 * Game.cpu.tickLimit && Game.cpu.bucket < Game.cpu.limit * 10) {
     console.log('Skipping tick ' + Game.time + ' due to lack of CPU.');
     return;
   }


### PR DESCRIPTION
ScreepsPl.us has a Game.cpu.tickLimit of 10100 for some weird reason