### PR TITLE
don't consider move-only creeps attackers

### DIFF
--- a/src/prototype_room_defense.js
+++ b/src/prototype_room_defense.js
@@ -26,9 +26,7 @@ Room.prototype.findAttackCreeps = function(object) {
       return true;
     }
   }
-  return true;
-  // TODO defender stop in rooms with (non attacking) enemies
-  //    return false;
+  return false;
 };
 
 Room.prototype.handleNukeAttack = function() {


### PR DESCRIPTION
sparr [Sep 24th at 9:00 AM] 
in #angels_public
why is the default here true instead of false? do we really want a notification when an unrecognized scout enters our room?

1 reply
tooangel [3 days ago] 
Yes, surely should be false. Also the notification are not necessary