### PR TITLE
add options to validPosition(), ignore paths when placing sourcers

### DIFF
--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -173,33 +173,33 @@ RoomPosition.prototype.isValid = function() {
   return true;
 };
 
-RoomPosition.prototype.validPosition = function() {
-  if (this.isBorder()) {
+RoomPosition.prototype.validPosition = function(opts = {}) {
+  if (!opts.ignoreBorder && this.isBorder()) {
     return false;
   }
-  if (this.checkForWall()) {
+  if (!opts.ignoreWall && this.checkForWall()) {
     return false;
   }
-  if (this.inPositions()) {
+  if (!opts.ignorePositions && this.inPositions()) {
     return false;
   }
-  if (this.inPath()) {
+  if (!opts.ignorePath && this.inPath()) {
     return false;
   }
   return true;
 };
 
-RoomPosition.prototype.getFirstNearPosition = function() {
-  return this.findNearPosition().next().value;
+RoomPosition.prototype.getFirstNearPosition = function(...args) {
+  return this.findNearPosition(...args).next().value;
 };
 
-RoomPosition.prototype.getBestNearPosition = function() {
+RoomPosition.prototype.getBestNearPosition = function(...args) {
   return _.max(Array.from(this.findNearPosition()), (pos) => Array.from(pos.findNearPosition()).length);
 };
 
-RoomPosition.prototype.findNearPosition = function* () {
+RoomPosition.prototype.findNearPosition = function* (...args) {
   for (const posNew of this.getAllAdjacentPositions()) {
-    if (!posNew.validPosition()) {
+    if (!posNew.validPosition(...args)) {
       //        console.log(posNew + ' - invalid');
       continue;
     }

--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -194,7 +194,7 @@ RoomPosition.prototype.getFirstNearPosition = function(...args) {
 };
 
 RoomPosition.prototype.getBestNearPosition = function(...args) {
-  return _.max(Array.from(this.findNearPosition()), (pos) => Array.from(pos.findNearPosition()).length);
+  return _.max(Array.from(this.findNearPosition(...args)), (pos) => Array.from(pos.findNearPosition(...args)).length);
 };
 
 RoomPosition.prototype.findNearPosition = function* (...args) {

--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -3,7 +3,7 @@
 Room.prototype.initSetController = function() {
   if (this.controller) {
     const costMatrix = this.getMemoryCostMatrix();
-    const upgraderPos = this.controller.pos.getBestNearPosition();
+    const upgraderPos = this.controller.pos.getBestNearPosition({ignorePositions: true, ignorePath: true});
     this.memory.position.creep[this.controller.id] = upgraderPos;
     costMatrix.set(upgraderPos.x, upgraderPos.y, config.layout.creepAvoid);
     this.setMemoryCostMatrix(costMatrix);
@@ -40,13 +40,15 @@ Room.prototype.initSetMinerals = function() {
 
 Room.prototype.initSetStorageAndPathStart = function() {
   const costMatrix = this.getMemoryCostMatrix();
-  const storagePos = this.memory.position.creep[this.controller.id].getBestNearPosition();
+  const upgraderPos = this.memory.position.creep[this.controller.id];
+  const storagePos = upgraderPos.getBestNearPosition({ignorePath: true});
+
   this.memory.position.structure.storage.push(storagePos);
   // TODO should also be done for the other structures
   costMatrix.set(storagePos.x, storagePos.y, config.layout.structureAvoid);
   this.setMemoryCostMatrix(costMatrix);
 
-  this.memory.position.creep.pathStart = storagePos.getFirstNearPosition();
+  this.memory.position.creep.pathStart = storagePos.getFirstNearPosition({ignorePath: true});
 
   const route = [{
     room: this.name,

--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -14,7 +14,7 @@ Room.prototype.initSetSources = function() {
   const sources = this.find(FIND_SOURCES);
   const costMatrix = this.getMemoryCostMatrix();
   for (const source of sources) {
-    const sourcer = source.pos.getFirstNearPosition();
+    const sourcer = source.pos.getFirstNearPosition({ignorePath: true});
     this.memory.position.creep[source.id] = sourcer;
     // TODO E.g. E11S8 it happens that sourcer has no position
     if (sourcer) {


### PR DESCRIPTION
Currently attempting to re-place creep positions in a room is not idempotent because they will avoid the paths previously planned to reach them. This patch introduces a way to pass options down through the relevant calls so that validPosition can be told to ignore specific position features.