### PR TITLE
Restrict new room claiming on `cpu.limit`

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -90,6 +90,7 @@ global.config = {
     numberOfNextroomers: 10,
     nextroomerInterval: 500,
     maxRooms: 20,
+    cpuPerRoom: 13, // Necessary CPU per room, prevent claiming new rooms
     revive: true,
     maxDistance: 17,
     minNewRoomDistance: 2,

--- a/src/config_brain_nextroom.js
+++ b/src/config_brain_nextroom.js
@@ -1,7 +1,10 @@
 'use strict';
 
 brain.handleNextroom = function() {
-  if (Memory.myRooms && Memory.myRooms.length < Game.gcl.level && Memory.myRooms.length < config.nextRoom.maxRooms) {
+  if (Memory.myRooms &&
+    Memory.myRooms.length < Game.gcl.level &&
+    Memory.myRooms.length < config.nextRoom.maxRooms &&
+    (Memory.myRooms.length + 1) * config.nextRoom.cpuPerRoom < Game.cpu.limit) {
     if (Game.time % config.nextRoom.ttlPerRoomForScout === 0) {
       for (const roomName of Memory.myRooms) {
         const room = Game.rooms[roomName];


### PR DESCRIPTION
Introduce `config.nextRoom.cpuPerRoom` to be able to set min CPU
per room and avoid claiming of new rooms.