### PR TITLE
Make two harvester RCL > 6 dependent on the energyAvailable

### DIFF
--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -273,7 +273,7 @@ Room.prototype.getHarvesterAmount = function() {
     if (this.storage.store.energy < config.creep.energyFromStorageThreshold && this.controller.level < 5) {
       amount = 3;
     }
-    if (this.storage.store.energy > 2 * config.creep.energyFromStorageThreshold && this.controller.level > 6) {
+    if (this.storage.store.energy > 2 * config.creep.energyFromStorageThreshold && this.controller.level > 6 && this.energyAvailable > 2000) {
       amount = 2;
     }
     if (!this.storage.my) {


### PR DESCRIPTION
Got stuck in e.g. E21N8, two harvester for switching at the storage,
only filling two extensions, blocking the path for other creeps.