### PR TITLE
Rewrite findPropertyFilter

### DIFF
--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -237,7 +237,7 @@ Creep.prototype.buildRoad = function() {
 
   const creep = this;
 
-  let constructionSites = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD], false, {
+  let constructionSites = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD], {
     filter: (cs) => creep.pos.getRangeTo(cs.pos) < 4,
   });
 

--- a/src/prototype_creep_clean.js
+++ b/src/prototype_creep_clean.js
@@ -57,7 +57,8 @@ Creep.prototype.cleanController = function() {
   }
   for (const pos of search.path) {
     const posObject = new RoomPosition(pos.x, pos.y, this.room.name);
-    const structures = posObject.findInRangePropertyFilter(FIND_STRUCTURES, 1, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true, {
+    const structures = posObject.findInRangePropertyFilter(FIND_STRUCTURES, 1, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {
+      inverse: true,
       filter: (object) => object.ticksToDecay !== null,
     });
 
@@ -91,7 +92,8 @@ Creep.prototype.cleanExits = function() {
     }
     if (!exit.isEqualTo(posLast.x, posLast.y)) {
       const pos = new RoomPosition(posLast.x, posLast.y, this.room.name);
-      const structure = pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true, {
+      const structure = pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {
+        inverse: true,
         filter: (object) => object.ticksToDecay !== null,
       });
 
@@ -116,7 +118,8 @@ Creep.prototype.cleanSetTargetId = function() {
       //      this.log('clean exits');
       return true;
     }
-    let structure = this.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true, {
+    let structure = this.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {
+      inverse: true,
       filter: (object) => object.ticksToDecay !== null,
     });
     if (structure !== null) {

--- a/src/prototype_creep_fight.js
+++ b/src/prototype_creep_fight.js
@@ -136,7 +136,7 @@ Creep.prototype.handleDefender = function() {
 };
 
 Creep.prototype.findClosestRampart = function() {
-  return this.pos.findClosestByRangePropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_RAMPART], false, {
+  return this.pos.findClosestByRangePropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_RAMPART], {
     filter: (rampart) => this.pos.getRangeTo(rampart) > 0 && !rampart.pos.checkForObstacleStructure(),
   });
 };

--- a/src/prototype_creep_harvest.js
+++ b/src/prototype_creep_harvest.js
@@ -67,7 +67,7 @@ Creep.prototype.spawnCarry = function() {
   if (resourceAtPosition > parts.carryParts.carry * CARRY_CAPACITY) {
     Game.rooms[this.memory.base].checkRoleToSpawn('carry', 0, this.memory.routing.targetId, this.memory.routing.targetRoom, carrySettings);
   } else if (resourceAtPosition <= HARVEST_POWER * parts.sourcerWork) {
-    const nearCarries = this.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 2, 'memory.role', ['carry'], false, {
+    const nearCarries = this.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 2, 'memory.role', ['carry'], {
       filter: (creep) => creep.memory.routing.targetId === this.memory.routing.targetId,
     });
     if (nearCarries.length > 1) {

--- a/src/prototype_creep_mineral.js
+++ b/src/prototype_creep_mineral.js
@@ -148,7 +148,7 @@ function cleanUpLabs(creep) {
       break;
     }
   } else {
-    const lab = creep.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], false, {
+    const lab = creep.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], {
       filter: (lab) => lab.mineralAmount > 0,
     });
     if (lab === null) {
@@ -222,7 +222,7 @@ function checkBoostAction(creep) {
   const labEmpty = (object) => !object.mineralType || object.mineralType === null;
 
   for (mineral of Object.keys(room.memory.boosting)) {
-    let labs = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], false, {
+    let labs = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], {
       filter: labForMineral,
     });
     if (labs.length > 0) {
@@ -235,7 +235,7 @@ function checkBoostAction(creep) {
       return true;
     }
 
-    labs = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], false, {
+    labs = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], {
       filter: labEmpty,
     });
     if (labs.length > 0) {
@@ -553,7 +553,7 @@ Creep.prototype.boost = function() {
       for (const action of Object.keys(BOOSTS[part][boost])) {
         this.log('boost: ' + part + ' ' + boost + ' ' + action);
         if (unit.boostActions.indexOf(action) > -1) {
-          const labs = this.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], false, {
+          const labs = this.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_LAB], {
             filter: findLabs,
           });
           if (this.room.terminal.store[boost] || labs.length > 0) {

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -14,7 +14,7 @@ Creep.prototype.harvesterBeforeStorage = function() {
   }
 
   methods.push(Creep.transferEnergy);
-  const structures = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_CONTROLLER], true);
+  const structures = this.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_CONTROLLER], {inverse: true});
   if (structures.length > 0) {
     methods.push(Creep.constructTask);
   }
@@ -260,7 +260,7 @@ Creep.prototype.buildContainer = function() {
 };
 
 Creep.prototype.pickupEnergy = function() {
-  const resources = this.room.findPropertyFilter(FIND_DROPPED_RESOURCES, 'resourceType', [RESOURCE_ENERGY], false, {
+  const resources = this.room.findPropertyFilter(FIND_DROPPED_RESOURCES, 'resourceType', [RESOURCE_ENERGY], {
     filter: Creep.pickableResources(this),
   });
   if (resources.length > 0) {
@@ -440,7 +440,7 @@ Creep.prototype.transferToStructures = function() {
 };
 
 Creep.prototype.getEnergyFromSourcer = function() {
-  const sourcers = this.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 1, 'memory.role', ['sourcer'], false, {
+  const sourcers = this.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 1, 'memory.role', ['sourcer'], {
     filter: (creep) => creep.carry.energy > 0,
   });
   if (sourcers.length > 0) {
@@ -539,7 +539,7 @@ Creep.prototype.setHasEnergy = function() {
 };
 
 Creep.prototype.getDroppedEnergy = function() {
-  const target = this.pos.findClosestByRangePropertyFilter(FIND_DROPPED_RESOURCES, 'resourceType', [RESOURCE_ENERGY], false, {
+  const target = this.pos.findClosestByRangePropertyFilter(FIND_DROPPED_RESOURCES, 'resourceType', [RESOURCE_ENERGY], {
     filter: (object) => object.amount > 0,
   });
   if (target === null) {
@@ -600,7 +600,7 @@ Creep.prototype.buildConstructionSite = function(target) {
 Creep.prototype.construct = function() {
   let target;
   if (this.memory.role === 'nextroomer') {
-    target = this.pos.findClosestByRangePropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART], true);
+    target = this.pos.findClosestByRangePropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART], {inverse: true});
   } else {
     target = this.pos.findClosestByRange(FIND_CONSTRUCTION_SITES);
   }
@@ -619,7 +619,7 @@ Creep.prototype.construct = function() {
 };
 
 Creep.prototype.getTransferTargetStructure = function() {
-  const structure = this.pos.findClosestByRangePropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER], false, {
+  const structure = this.pos.findClosestByRangePropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER], {
     filter: (structure) => structure.energy < structure.energyCapacity,
   });
   if (structure === null) {
@@ -684,7 +684,7 @@ const callStructurer = function(creep) {
   if (structurers.length > 0) {
     return false;
   }
-  const resourceStructures = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+  const resourceStructures = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {inverse: true});
   if (resourceStructures.length > 0 && !creep.room.controller.my) {
     creep.log('Call structurer from ' + creep.memory.base + ' because of ' + resourceStructures[0].structureType);
     Game.rooms[creep.memory.base].checkRoleToSpawn('structurer', 1, undefined, creep.room.name);

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -117,7 +117,8 @@ Creep.prototype.getEnergyFromHostileStructures = function() {
   if (this.carry.energy) {
     return false;
   }
-  let hostileStructures = this.room.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_RAMPART, STRUCTURE_EXTRACTOR, STRUCTURE_OBSERVER], true, {
+  let hostileStructures = this.room.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_RAMPART, STRUCTURE_EXTRACTOR, STRUCTURE_OBSERVER], {
+    inverse: true,
     filter: Room.structureHasEnergy,
   });
   if (!hostileStructures.length) {
@@ -222,7 +223,7 @@ Creep.prototype.repairStructure = function() {
   }
 
   // Repair low ramparts
-  const lowRamparts = this.pos.findInRangePropertyFilter(FIND_STRUCTURES, 4, 'structureType', [STRUCTURE_RAMPART], false, {
+  const lowRamparts = this.pos.findInRangePropertyFilter(FIND_STRUCTURES, 4, 'structureType', [STRUCTURE_RAMPART], {
     filter: (rampart) => rampart.hits < 10000,
   });
 
@@ -247,7 +248,7 @@ Creep.prototype.repairStructure = function() {
     if (range <= 3) {
       this.build(target);
       this.memory.step = 0;
-      const targetNew = this.pos.findClosestByRangePropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], false, {
+      const targetNew = this.pos.findClosestByRangePropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], {
         filter: (object) => object.id !== target.id,
       });
       if (targetNew !== null) {
@@ -271,7 +272,7 @@ Creep.prototype.repairStructure = function() {
   }
 
   const creep = this;
-  const structure = this.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], false, {
+  const structure = this.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL], {
     // Newbie zone walls have no hits
     filter: (object) => object.hits && object.hits < Math.min(creep.memory.step, object.hitsMax),
   });

--- a/src/prototype_roomPosition.js
+++ b/src/prototype_roomPosition.js
@@ -220,28 +220,13 @@ RoomPosition.wrapFindMethod = (methodName, extraParamsCount) => function(findTar
   if (_.isNumber(findTarget)) {
     const objects = this.getRoom().findPropertyFilter(findTarget, ...propertyFilterParams);
     return this[methodName](objects, ...extraParams);
-  } else {
-    return this[methodName](findTarget, ...extraParams, Room.getPropertyFilterOptsObj(...propertyFilterParams));
   }
   /* eslint-enable no-invalid-this */
 };
 
 /**
- * Restore RoomPosition object after JSON serialisation.
  *
- * @param {object} json JSON object
- * @param {number} json.x X coordinate
- * @param {number} json.y Y coordinate
- * @param {string} json.roomName Name of the room
- * @return {RoomPosition} RoomPosition object
- */
-RoomPosition.fromJSON = function(json) {
-  return new RoomPosition(json.x, json.y, json.roomName);
-};
-
-/**
- *
- * @param {Number|RoomObject[]}  findTarget One of the FIND constant. e.g. [FIND_MY_STRUCTURES] or array of RoomObject to apply filters
+ * @param {Number}  findTarget One of the FIND constant. e.g. [FIND_MY_STRUCTURES] or array of RoomObject to apply filters
  * @param range
  * @param {String}  property The property to filter on. e.g. 'structureType' or 'memory.role'
  * @param {Array}  properties The properties to filter. e.g. [STRUCTURE_ROAD, STRUCTURE_RAMPART]
@@ -254,7 +239,7 @@ RoomPosition.prototype.findInRangePropertyFilter = RoomPosition.wrapFindMethod('
 
 /**
  *
- * @param {Number|RoomObject[]}  findTarget One of the FIND constant. e.g. [FIND_MY_STRUCTURES] or array of RoomObject to apply filters
+ * @param {Number}  findTarget One of the FIND constant. e.g. [FIND_MY_STRUCTURES] or array of RoomObject to apply filters
  * @param {String}  property The property to filter on. e.g. 'structureType' or 'memory.role'
  * @param {Array}  properties The properties to filter. e.g. [STRUCTURE_ROAD, STRUCTURE_RAMPART]
  * @param {Boolean} [without=false] Exclude or include the properties to find.
@@ -275,6 +260,19 @@ RoomPosition.prototype.findClosestByRangePropertyFilter = RoomPosition.wrapFindM
  * @return {Array} the objects returned in an array.
  */
 RoomPosition.prototype.findClosestByPathPropertyFilter = RoomPosition.wrapFindMethod('findClosestByPath', 0);
+
+/**
+ * Restore RoomPosition object after JSON serialisation.
+ *
+ * @param {object} json JSON object
+ * @param {number} json.x X coordinate
+ * @param {number} json.y Y coordinate
+ * @param {string} json.roomName Name of the room
+ * @return {RoomPosition} RoomPosition object
+ */
+RoomPosition.fromJSON = function(json) {
+  return new RoomPosition(json.x, json.y, json.roomName);
+};
 
 /**
  * Given a direction-like number, wrap it to fit in 1-8

--- a/src/prototype_room_basebuilder.js
+++ b/src/prototype_room_basebuilder.js
@@ -167,7 +167,7 @@ Room.prototype.checkWrongStructure = function() {
   //  this.log('checkWrongStructure: controller.level < 6');
   //  return false;
   // }
-  const structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
+  const structures = this.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], {inverse: true});
   for (const structure of structures) {
     if (this.destroyStructure(structure)) {
       return true;
@@ -283,7 +283,7 @@ Room.prototype.buildStructures = function() {
     return false;
   }
 
-  const constructionSites = this.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_ROAD], true);
+  const constructionSites = this.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_WALL, STRUCTURE_ROAD], {inverse: true});
   if (constructionSites.length > 0) {
     //    this.log('basebuilder.setup: Too many construction sites');
     return true;

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -32,11 +32,11 @@ Room.prototype.getCostMatrixCallback = function(end, excludeStructures, oneRoom,
 
     if (excludeStructures) {
       // TODO excluding structures, for the case where the spawn is in the wrong spot (I guess this can be handled better)
-      const structures = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+      const structures = room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {inverse: true});
       this.setCostMatrixStructures(costMatrix, structures, config.layout.structureAvoid);
 
       // TODO repairer got stuck at walls, why?
-      const constructionSites = room.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], true);
+      const constructionSites = room.findPropertyFilter(FIND_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_CONTAINER], {inverse: true});
       this.setCostMatrixStructures(costMatrix, constructionSites, config.layout.structureAvoid);
     }
 

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -417,7 +417,7 @@ Room.prototype.checkAndSpawnSourcer = function() {
   let source;
   const isSourcer = (object) => object.memory.routing.targetId === source.id && object.memory.routing.targetRoom === source.pos.roomName;
   for (source of sources) {
-    const sourcers = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['sourcer'], false, {
+    const sourcers = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['sourcer'], {
       filter: isSourcer,
     });
     if (sourcers.length === 0) {

--- a/src/prototype_room_defense.js
+++ b/src/prototype_room_defense.js
@@ -51,7 +51,7 @@ Room.prototype.handleNukeAttack = function() {
   };
 
   for (const nuke of nukes) {
-    const structures = nuke.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 4, 'structureType', [STRUCTURE_ROAD, STRUCTURE_RAMPART, STRUCTURE_WALL], true);
+    const structures = nuke.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 4, 'structureType', [STRUCTURE_ROAD, STRUCTURE_RAMPART, STRUCTURE_WALL], {inverse: true});
     this.log('Nuke attack !!!!!');
     for (const structure of structures) {
       const lookConstructionSites = structure.pos.lookFor(LOOK_CONSTRUCTION_SITES);
@@ -137,14 +137,16 @@ Room.prototype.handleTower = function() {
       }
     }
 
-    const lowRampart = tower.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART], false, {
+    const lowRampart = tower.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_RAMPART], {
       filter: (rampart) => rampart.hits < 10000,
     });
 
     let repair = lowRampart;
     if (lowRampart === null) {
-      repair = tower.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType',
-        [STRUCTURE_WALL, STRUCTURE_RAMPART], true, {filter: repairableStructures});
+      repair = tower.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_WALL, STRUCTURE_RAMPART], {
+        inverse: true,
+        filter: repairableStructures,
+      });
       tower.repair(repair);
     }
   }

--- a/src/prototype_room_external.js
+++ b/src/prototype_room_external.js
@@ -173,7 +173,7 @@ Room.prototype.handleOccupiedRoom = function() {
 
     // TODO trigger everytime?
     if (!this.controller.safeMode) {
-      const myCreeps = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['scout'], true);
+      const myCreeps = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['scout'], {inverse: true});
       if (myCreeps.length > 0) {
         return false;
       }

--- a/src/prototype_room_mineral.js
+++ b/src/prototype_room_mineral.js
@@ -45,7 +45,7 @@ Room.prototype.reactions = function() {
       return;
     }
 
-    const labsAll = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_LAB], false, {
+    const labsAll = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_LAB], {
       filter: (object) => !object.mineralType || object.mineralType === result.result,
     });
 
@@ -68,7 +68,7 @@ Room.prototype.reactions = function() {
     };
 
     for (lab of labsAll) {
-      const labsNear = lab.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 2, 'structureType', [STRUCTURE_LAB], false, {
+      const labsNear = lab.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 2, 'structureType', [STRUCTURE_LAB], {
         filter: getNearLabs,
       });
 

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -64,7 +64,7 @@ Room.prototype.handleLinks = function() {
     return;
   }
 
-  const links = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_LINK], false, {
+  const links = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_LINK], {
     filter: (link) => link.id !== linkStorage.id,
   });
 
@@ -310,7 +310,7 @@ Room.prototype.executeRoom = function() {
     this.memory.active = true;
   }
 
-  const nextroomers = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['nextroomer'], false, {
+  const nextroomers = this.findPropertyFilter(FIND_MY_CREEPS, 'memory.role', ['nextroomer'], {
     filter: (object) => object.memory.base !== this.name,
   });
   const building = nextroomers.length > 0 && this.controller.level < 4;
@@ -323,7 +323,7 @@ Room.prototype.executeRoom = function() {
 
   if (this.memory.attackTimer > 100) {
     // TODO better metric for SafeMode
-    const enemies = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], true);
+    const enemies = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], {inverse: true});
     if (enemies > 0) {
       this.controller.activateSafeMode();
     }
@@ -345,7 +345,7 @@ Room.prototype.executeRoom = function() {
     }
   }
 
-  const idiotCreeps = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], true);
+  const idiotCreeps = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], {inverse: true});
   if (idiotCreeps.length > 0) {
     for (const idiotCreep of idiotCreeps) {
       brain.increaseIdiot(idiotCreep.owner.username);
@@ -385,7 +385,7 @@ Room.prototype.executeRoom = function() {
     this.checkRoleToSpawn('upgrader', 1, this.controller.id);
   }
 
-  const constructionSites = this.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD, STRUCTURE_WALL, STRUCTURE_RAMPART], true);
+  const constructionSites = this.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_ROAD, STRUCTURE_WALL, STRUCTURE_RAMPART], {inverse: true});
   if (constructionSites.length > 0) {
     let amount = 1;
     for (const cs of constructionSites) {
@@ -502,7 +502,7 @@ Room.prototype.setRoomInactive = function() {
     addToIdiot = Math.max(addToIdiot, tokens[0].price);
   }
   this.log('Increase idiot by subscription token');
-  const idiotCreeps = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], true);
+  const idiotCreeps = this.findPropertyFilter(FIND_HOSTILE_CREEPS, 'owner.username', ['Invader'], {inverse: true});
   if (idiotCreeps.length > 0) {
     for (const idiotCreep of idiotCreeps) {
       brain.increaseIdiot(idiotCreep.owner.username, addToIdiot);

--- a/src/prototype_room_utils.js
+++ b/src/prototype_room_utils.js
@@ -26,55 +26,65 @@ Room.prototype.nearestRoomName = function(roomsNames, limit) {
   return _.min(roomsNames, sortByLinearDistance);
 };
 
-Room.getPropertyFilterOptsObj = function(property, properties, without = false, opts = {}) {
-  const table = {};
-  _.each(properties, (e) => {
-    table[e] = true;
-  });
-  const propParts = property.split('.');
-  return Object.assign({}, opts, {
-    filter: (s) => {
-      let propValue = s;
-      for (const prop of propParts) {
-        propValue = propValue[prop];
-      }
-      return without ? !table[propValue] : table[propValue] && (!opts.filter || opts.filter(s));
-    },
-  });
-};
-
 /**
  * use a static array for filter a find.
  *
  * @param  {Number}  findTarget      one of the FIND constant. e.g. [FIND_MY_STRUCTURES]
  * @param  {String}  property        the property to filter on. e.g. 'structureType' or 'memory.role'
  * @param  {Array}  properties      the properties to filter. e.g. [STRUCTURE_ROAD, STRUCTURE_RAMPART]
- * @param  {Boolean} [without=false] Exclude or include the properties to find.
  * @param  {object} [opts={}] Additional options.
  * @param  {function} [opts.filter] Additional filter that wil be applied after cache.
+ * @param  {Boolean} [opts.inverse=false] Exclude or include the properties to find.
+ * @param  {Number} [opts.timeSpan=0] Return cached data even if it is outdated by `timeSpan` ticks.
  * @return {Array}                  the objects returned in an array.
  */
-Room.prototype.findPropertyFilter = function(findTarget, property, properties, without = false, opts = {}) {
-  const key = `${findTarget} ${property} ${properties} ${without}`;
-  this.checkCache();
-
-  let result;
-  if (cache.rooms[this.name].find[key] && cache.rooms[this.name].find[key].time === Game.time) {
-    // this.log(`Found ${key} ${cache.rooms[this.name].find[key]}`);
-    result = cache.rooms[this.name].find[key].result;
+Room.prototype.findPropertyFilter = function(findTarget, property, properties, opts = {}) {
+  const {filter, timeSpan = 0, inverse = false} = opts;
+  const cache = this._findPropertyFilterCacheOne(findTarget, property, properties, timeSpan, inverse);
+  if (cache.resolveTime !== Game.time) {
+    this._findPropertyFilterResolveOutdatedCacheOne(cache);
+  }
+  if (filter) {
+    return _.filter(cache.result, filter);
   } else {
-    const opts = Room.getPropertyFilterOptsObj(property, properties, without);
-    result = this.find(findTarget, opts);
-    cache.rooms[this.name].find[key] = {
+    return cache.result;
+  }
+};
+
+const localFindCache = {};
+
+Room.prototype._findPropertyFilterCacheTwo = function(findTarget, property, timeSpan) {
+  const key = `${this.name} ${findTarget} ${property}`;
+  if (!localFindCache[key] || localFindCache[key].time < Game.time + timeSpan) {
+    localFindCache[key] = {
       time: Game.time,
-      result: result,
+      result: _.groupBy(this.find(findTarget), property),
     };
   }
-  if (opts.filter) {
-    return _.filter(result, opts.filter);
-  } else {
-    return result;
+  return localFindCache[key];
+};
+
+Room.prototype._findPropertyFilterCacheOne = function(findTarget, property, properties, timeSpan, inverse) {
+  const key = `${this.name} ${findTarget} ${property} ${properties} ${inverse}`;
+  if (!localFindCache[key] || localFindCache[key].time < Game.time + timeSpan) {
+    const cacheTwoItem = this._findPropertyFilterCacheTwo(findTarget, property, timeSpan);
+    const cacheOneItem = localFindCache[key] = {
+      resolveTime: Game.time,
+      time: Game.time,
+      result: [],
+    };
+    for (const propertyValue of Object.keys(cacheTwoItem.result)) {
+      if (properties.includes(propertyValue) !== inverse) {
+        Array.prototype.push.apply(cacheOneItem.result, cacheTwoItem.result[propertyValue]);
+      }
+    }
   }
+  return localFindCache[key];
+};
+
+Room.prototype._findPropertyFilterResolveOutdatedCacheOne = function(cache) {
+  cache.result = cache.result.map((o) => Game.getObjectById(o.id)).filter((o) => o);
+  cache.resolveTime = Game.time;
 };
 
 Room.prototype.closestSpawn = function(target) {

--- a/src/role_atkeeper.js
+++ b/src/role_atkeeper.js
@@ -70,7 +70,8 @@ roles.atkeeper.action = function(creep) {
     }
 
     if (!target || target === null) {
-      const myCreep = creep.pos.findClosestByRangePropertyFilter(FIND_MY_CREEPS, 'memory.role', ['atkeeper'], true, {
+      const myCreep = creep.pos.findClosestByRangePropertyFilter(FIND_MY_CREEPS, 'memory.role', ['atkeeper'], {
+        inverse: true,
         filter: (creep) => creep.hits < creep.hitsMax,
       });
       if (myCreep !== null) {

--- a/src/role_atkeepermelee.js
+++ b/src/role_atkeepermelee.js
@@ -35,7 +35,7 @@ roles.atkeepermelee.action = function(creep) {
     const range = creep.pos.getRangeTo(target);
     if (range > 1) {
       if (range > 7) {
-        const sourcers = creep.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 3, 'memory.role', ['sourcer'], false, {
+        const sourcers = creep.pos.findInRangePropertyFilter(FIND_MY_CREEPS, 3, 'memory.role', ['sourcer'], {
           filter: (target) => target.hits < target.hitsMax,
         });
 

--- a/src/role_autoattackmelee.js
+++ b/src/role_autoattackmelee.js
@@ -46,7 +46,7 @@ roles.autoattackmelee.action = function(creep) {
   if (spawn === null) {
     const hostileCreep = creep.findClosestEnemy();
     if (hostileCreep === null) {
-      const structures = creep.pos.findClosestByRangePropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER], true);
+      const structures = creep.pos.findClosestByRangePropertyFilter(FIND_HOSTILE_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER], {inverse: true});
 
       if (structures === null) {
         const constructionSites = creep.pos.findClosestByRange(FIND_CONSTRUCTION_SITES);

--- a/src/role_nextroomer.js
+++ b/src/role_nextroomer.js
@@ -205,7 +205,7 @@ roles.nextroomer.settle = function(creep) {
   }
 
   if (creep.carry.energy > 0) {
-    const towers = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_TOWER], false, {
+    const towers = creep.room.findPropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_TOWER], {
       filter: (object) => object.energy < 10,
     });
     if (towers.length) {
@@ -233,7 +233,7 @@ roles.nextroomer.settle = function(creep) {
     methods.push(Creep.constructTask);
   }
 
-  const structures = creep.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], true);
+  const structures = creep.room.findPropertyFilter(FIND_MY_CONSTRUCTION_SITES, 'structureType', [STRUCTURE_RAMPART, STRUCTURE_CONTROLLER], {inverse: true});
   if (creep.room.controller.level >= 3 && structures.length > 0) {
     methods.push(Creep.constructTask);
   }

--- a/src/role_storagefiller.js
+++ b/src/role_storagefiller.js
@@ -101,7 +101,7 @@ roles.storagefiller.action = function(creep) {
     }
   }
 
-  const towers = creep.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 1, 'structureType', [STRUCTURE_TOWER], false, {
+  const towers = creep.pos.findInRangePropertyFilter(FIND_MY_STRUCTURES, 1, 'structureType', [STRUCTURE_TOWER], {
     filter: (tower) => tower.energy <= 0.5 * tower.energyCapacity,
   });
 

--- a/src/role_structurer.js
+++ b/src/role_structurer.js
@@ -57,7 +57,7 @@ roles.structurer.preMove = function(creep, directions) {
 
 roles.structurer.action = function(creep) {
   if (!creep.room.controller || !creep.room.controller.my) {
-    const structure = creep.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD], true, {
+    const structure = creep.pos.findClosestByRangePropertyFilter(FIND_STRUCTURES, 'structureType', [STRUCTURE_CONTROLLER, STRUCTURE_ROAD], {
       filter: (object) => object.ticksToDecay !== null,
     });
     creep.dismantle(structure);


### PR DESCRIPTION
- Add one more level of caching. CPU usage reduced by half
- Add option to use outdated finds for not critical tasks (for example may be used to reduce rate of structures searches, as they are changed rarely). This option is unused for now
- Move `without` parameter as one of `opts` properties and refactor usages