### PR TITLE
Upgrade controller to full `ticksToDowngrade`

### DIFF
--- a/src/role_nextroomer.js
+++ b/src/role_nextroomer.js
@@ -194,7 +194,10 @@ roles.nextroomer.settle = function(creep) {
   });
   if (hostileCreeps.length) {
     room.memory.underSiege = true;
-    if (creep.room.controller.ticksToDowngrade < CONTROLLER_DOWNGRADE[creep.room.controller.level] / 10 || creep.room.controller.level === 1) {
+    if (creep.room.controller.level === 1 ||
+        creep.room.controller.ticksToDowngrade < CONTROLLER_DOWNGRADE[creep.room.controller.level] / 10 ||
+        (creep.room.controller.ticksToDowngrade < CONTROLLER_DOWNGRADE[creep.room.controller.level] && creep.pos.getRangeTo(creep.room.controller.pos) <= 3)
+    ) {
       const methods = [Creep.getEnergy, Creep.upgradeControllerTask];
       return Creep.execute(creep, methods);
     }


### PR DESCRIPTION
In the past the `ticksToDowngrade` were resetted as soon as an upgrade
on the controller happen. Now it is only incremented.
Nextroomer logic is now, to upgrade controller if < 0.1
`ticksToDowngrade`, or if close to the controller.