### PR TITLE
Improve tests and the code accordding

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,7 @@ module.exports = function(grunt) {
     },
 
     exec: {
-      test_on_private_server: 'node utils/test.js',
+      test_on_private_server: 'node utils/test.js 100',
     },
   });
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "ignore": ["dist/*"],
+  "delay": "2500",
+  "ext": "js"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screeps-bot-tooangel",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "",
   "main": "src/main.js",
   "screeps_bot": true,

--- a/src/config.js
+++ b/src/config.js
@@ -23,13 +23,14 @@ global.config = {
   },
   visualizer: {
     enabled: false,
-    showRoomPaths: true,
+    showRoomPaths: false,
     showCreepPaths: false,
     showPathSearches: false,
     showStructures: false,
     showCreeps: false,
     showBlockers: false,
     showCostMatrixes: false,
+    showCostMatrixValues: false,
   },
 
   quests: {
@@ -59,7 +60,7 @@ global.config = {
   stats: {
     screepsPlusEnabled: false,
     screepsPlusToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRvb2FuZ2VscyIsImlhdCI6MTQ4MzU2MTU3OSwiYXVkIjoic2NyZWVwc3BsLnVzIiwiaXNzIjoic2NyZWVwc3BsLnVzIn0.NhobT7Jg8bOAg-MYqrYsgeMgXEVXGVYG9s3G9Qpfm-o',
-    enabled: true,
+    enabled: false,
     summary: false,
   },
 
@@ -74,6 +75,7 @@ global.config = {
       rooms: [], // Rooms for debug output, e.g. ['E21N8']
     },
     power: false,
+    reserver: false,
     nextroomer: false,
     quests: false,
     revive: false,
@@ -84,6 +86,7 @@ global.config = {
     energyTransfer: false,
     constructionSites: false,
     routing: false,
+    brain: false,
   },
 
   tower: {
@@ -166,10 +169,11 @@ global.config = {
     sizes: {
       0: [3, 3], // RCL 1
       550: [4, 4], // RCL 2
-      800: [6, 6], // RCL 3
-      1300: [6, 11], // RCL 4
-      1800: [8, 15], // RCL 5
-      2300: [11, 21], // RCL 6
+      600: [5, 3], // RCL 3 first extension, most of the roads should be build
+      800: [5, 3], // RCL 3
+      1300: [7, 4], // RCL 4
+      1800: [9, 5], // RCL 5
+      2300: [11, 6], // RCL 6
     },
     minSpawnRate: 50,
     // Percentage should increase from base to target room. Decrease may cause stack on border
@@ -181,7 +185,7 @@ global.config = {
 
   creep: {
     renewOffset: 0,
-    queueTtl: 100,
+    queueTtl: 150,
     structurer: true,
     structurerInterval: 1500,
     structurerMinEnergy: 1300,
@@ -220,16 +224,17 @@ global.config = {
   layout: {
     plainCost: 5,
     swampCost: 8,
-    borderAvoid: 20,
+    borderAvoid: 40,
     skLairAvoidRadius: 5,
-    skLairAvoid: 30,
-    wallAvoid: 10,
-    sourceAvoid: 20,
+    skLairAvoid: 50,
+    wallAvoid: 20,
+    plainAvoid: 10,
+    sourceAvoid: 60,
     pathAvoid: 1,
     structureAvoid: 0xFF,
     creepAvoid: 0xFF,
     wallThickness: 1,
-    version: 19,
+    version: 20,
   },
 
   terminal: {

--- a/src/config_brain_main.js
+++ b/src/config_brain_main.js
@@ -2,17 +2,8 @@
 
 global.cpuUsed = 0;
 
-// room execution via sigmoid function
-// all rooms execute every config.main.executeAll ticks
 brain.main.roomExecution = function() {
-  if (Game.time % config.main.executeAll === 0) {
-    Memory.myRooms = _(Game.rooms).filter((r) => r.execute()).map((r) => r.name).value();
-  } else {
-    /** @see https://github.com/TooAngel/screeps/pull/498#discussion-diff-165847270R92 */
-    const roomList = config.main.randomExecution ? _.shuffle(Game.rooms) : Game.rooms;
-    global.cpuUsed = Game.cpu.getUsed();
-    Memory.myRooms = _(roomList).filter(brain.main.roomFilter).map((r) => r.name).value();
-  }
+  Memory.myRooms = _(Game.rooms).filter((r) => r.execute()).map((r) => r.name).value();
 };
 
 brain.main.cleanUpDyingCreep = function(name) {

--- a/src/config_brain_memory.js
+++ b/src/config_brain_memory.js
@@ -36,16 +36,23 @@ brain.addToStats = function(name) {
 brain.handleUnexpectedDeadCreeps = function(name, creepMemory) {
   let hostiles = [];
   let room = {};
+  let memoryRoom = {};
+  if (creepMemory.room) {
+    room = Game.rooms[creepMemory.room];
+    memoryRoom = Memory.rooms[creepMemory.room];
+  }
   let structures = [];
   let sourceKeepers = [];
   if (Memory.creeps[name].routing && Memory.creeps[name].routing.route && Memory.creeps[name].routing.routePos && Memory.creeps[name].routing.route[Memory.creeps[name].routing.routePos]) {
-    room = Game.rooms[Memory.creeps[name].routing.route[Memory.creeps[name].routing.routePos].room];
-    hostiles = room.find(FIND_CREEPS);
-    structures = room.find(FIND_STRUCTURES);
-    sourceKeepers = this.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'owner.username', ['Source Keeper']);
+    // room = Game.rooms[Memory.creeps[name].routing.route[Memory.creeps[name].routing.routePos].room];
+    if (room) {
+      hostiles = room.find(FIND_CREEPS);
+      structures = room.find(FIND_STRUCTURES);
+      sourceKeepers = room.findPropertyFilter(FIND_HOSTILE_STRUCTURES, 'owner.username', ['Source Keeper']);
+    }
   }
-  if (hostiles.length === 0 || hostiles[0].owner.username !== 'Invader') {
-    console.log(`${Game.time} ${room.name} ${name} Not in Game.creeps lived ${Game.time - creepMemory.born} hostiles: ${hostiles.length} structures: ${structures.length} sourceKeepers: ${sourceKeepers} memory: ${JSON.stringify(Memory.creeps[name])}`); // eslint-disable-line max-len
+  if (hostiles.length === 0 || hostiles[0].owner.username !== 'Invader' || !(memoryRoom || {}).sourceKeeperRoom) {
+    console.log(`${Game.time} ${room.name} ${name} Not in Game.creeps lived ${Game.time - creepMemory.born} hostiles: ${hostiles.length} structures: ${structures.length} sourceKeepers: ${sourceKeepers.length} memory: ${JSON.stringify(Memory.creeps[name])} ${JSON.stringify(memoryRoom)}`); // eslint-disable-line max-len
   }
   if (Game.time - creepMemory.born < 20) {
     return;
@@ -192,6 +199,7 @@ Upgrade less: ${strings.upgradeLess}
 };
 
 brain.prepareMemory = function() {
+  brain.debugLog('brain', 'prepareMemory');
   Memory.username = Memory.username || _.chain(Game.rooms).map('controller').flatten().filter('my').map('owner.username').first().value();
   Memory.myRooms = Memory.myRooms || [];
   Memory.squads = Memory.squads || {};

--- a/src/config_brain_memory_market.js
+++ b/src/config_brain_memory_market.js
@@ -31,6 +31,7 @@ brain.getMarketOrderAverage = (type, resource) => Memory.orders[type][resource] 
 brain.getMarketOrder = (type, resource, property) => Memory.orders[type][resource] && Memory.orders[type][resource][property] ? Memory.orders[type][resource][property] : null;
 
 brain.buyPower = function() {
+  brain.debugLog('brain', 'buyPower');
   if (!config.market.buyPower) {
     return false;
   }
@@ -75,6 +76,7 @@ brain.handleIncomingTransactionsTimeFilter = (object) => {
 };
 
 brain.handleIncomingTransactions = function() {
+  brain.debugLog('brain', 'prepareMemory');
   const transactions = Game.market.incomingTransactions;
   const current = _.filter(transactions, brain.handleIncomingTransactionsTimeFilter);
 

--- a/src/config_brain_nextroom.js
+++ b/src/config_brain_nextroom.js
@@ -1,6 +1,7 @@
 'use strict';
 
 brain.handleNextroom = function() {
+  brain.debugLog('brain', 'handleNextroom');
   if (Memory.myRooms &&
     Memory.myRooms.length < Game.gcl.level &&
     Memory.myRooms.length < config.nextRoom.maxRooms &&

--- a/src/config_brain_quests.js
+++ b/src/config_brain_quests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 brain.handleQuests = function() {
+  brain.debugLog('brain', 'handleQuests');
   Memory.quests = Memory.quests || {};
   for (const id of Object.keys(Memory.quests)) {
     const quest = Memory.quests[id];

--- a/src/config_brain_squadmanager.js
+++ b/src/config_brain_squadmanager.js
@@ -57,6 +57,7 @@ brain.isFriend = function(name) {
 };
 
 brain.handleSquadmanager = function() {
+  brain.debugLog('brain', 'handleSquadmanager');
   for (const squadIndex of Object.keys(Memory.squads)) {
     const squad = Memory.squads[squadIndex];
     if (!squad.siege || Object.keys(squad.siege).length === 0) {

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,3 +1,9 @@
+brain.debugLog = function(type, ...messages) {
+  if (config.debug[type]) {
+    console.log(`${Game.time} ${messages.join(' ')}`);
+  }
+};
+
 Room.prototype.log = function(...messages) {
   console.log(`${Game.time} ${this.name.rpad(' ', 27)} ${messages.join(' ')}`);
 };

--- a/src/main.js
+++ b/src/main.js
@@ -10,9 +10,9 @@ require('visualizer');
 require('screepsplus');
 
 global.tickLimit = global.cpuLimit();
-global.load = _.round(Game.cpu.getUsed());
+global.load = Math.round(Game.cpu.getUsed());
 
-console.log(`${Game.time} Script reload Load: ${global.load} Bucket: ${Game.cpu.bucket}`);
+console.log(`${Game.time} Script reload - Load: ${global.load} tickLimit: ${Game.cpu.tickLimit} limit: ${Game.cpu.limit} Bucket: ${Game.cpu.bucket}`);
 
 brain.stats.init();
 brain.main.profilerInit();

--- a/src/prototype_creep_fight.js
+++ b/src/prototype_creep_fight.js
@@ -84,6 +84,17 @@ Creep.prototype.handleDefender = function() {
     return true;
   }
 
+  const invaderCores = this.room.find(
+    FIND_HOSTILE_STRUCTURES, {
+      filter: {structureType: STRUCTURE_INVADER_CORE},
+    },
+  );
+  if (invaderCores.length > 0) {
+    this.moveTo(invaderCores[0].pos);
+    this.rangedAttack(invaderCores[0]);
+    return true;
+  }
+
   this.moveRandom();
   return true;
 };

--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -175,6 +175,7 @@ Creep.prototype.getEnergyFromStorage = function() {
 };
 
 Creep.prototype.repairStructure = function() {
+  this.creepLog('repairStructure');
   if (this.memory.target) {
     const toRepair = Game.getObjectById(this.memory.target);
     if (!toRepair || toRepair === null) {
@@ -184,14 +185,17 @@ Creep.prototype.repairStructure = function() {
     }
 
     if (toRepair instanceof ConstructionSite) {
+      this.creepLog(`building constructionSite ${JSON.stringify(toRepair)}`);
       this.build(toRepair);
       this.moveToMy(toRepair.pos, 3);
       return true;
     } else if (toRepair.hits < 10000 || toRepair.hits < this.memory.step + 10000) {
+      this.creepLog(`repairing structure ${JSON.stringify(toRepair)}`);
       this.repair(toRepair);
       if (this.fatigue === 0) {
         const range = this.pos.getRangeTo(toRepair);
         if (range <= 3) {
+          this.creepLog(`moveRandom ${JSON.stringify(toRepair)}`);
           this.moveRandomWithin(toRepair);
         } else {
           this.creepLog('repairStructure moveToMy target:', JSON.stringify(toRepair.pos));

--- a/src/prototype_room_basebuilder.js
+++ b/src/prototype_room_basebuilder.js
@@ -101,7 +101,7 @@ Room.prototype.destroyStructure = function(structure) {
       }
       return false;
     }
-    this.log(`Spawn ${structure.pos} is misplaced, not in positions ${JSON.stringify(this.memory.position.structure[structure.structureType])} (prototype_room_basebuilder.destroyStructure)`);
+    this.log(`Spawn [${structure.pos.x}, ${structure.pos.y}] is misplaced, not in positions ${JSON.stringify(this.memory.position.structure[structure.structureType].map((o) => `${o.x}, ${o.y}`))} (prototype_room_basebuilder.destroyStructure)`); // eslint-disable-line max-len
     this.memory.misplacedSpawn = true;
 
     // Build ramparts around the spawn if wallThickness > 1

--- a/src/prototype_room_controller.js
+++ b/src/prototype_room_controller.js
@@ -11,11 +11,16 @@ Room.prototype.buildBase = function() {
   this.memory.controllerLevel = this.memory.controllerLevel || {};
 
   if (!this.memory.controllerLevel['setup_level_' + this.controller.level]) {
-    if (this.controller.level === 1) {
-      if (!this.memory.position) {
-        this.setup();
+    if (Game.cpu.tickLimit > Game.cpu.bucket) {
+      // this.log(`Skipping room_controller.js execution CPU limit: ${Game.cpu.limit} tickLimit: ${Game.cpu.tickLimit} bucket: ${Game.cpu.bucket}`);
+      return;
+    }
+    if (this.controller.level === 1 || this.controller.level === 2) {
+      if (!this.setup()) {
+        return;
       }
     }
+    this.updateCostMatrix();
     resetCounters(this);
     this.memory.controllerLevel['setup_level_' + this.controller.level] = Game.time;
   }
@@ -76,6 +81,7 @@ Room.prototype.buildBase = function() {
 
   // version: this.memory.position.version is maybe not the best idea
   if (!this.memory.position || this.memory.position.version !== config.layout.version) {
+    this.debugLog('baseBuilding', 'New layout version, rebuilding');
     this.setup();
   }
 };

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -42,7 +42,7 @@ Room.prototype.spawnCheckForCreate = function() {
     return true;
   }
   if (creep.ttl === 0) {
-    this.log('TTL reached, skipping: ' + JSON.stringify(_.omit(creep, ['level'])));
+    this.log('TTL reached, skipping: ' + JSON.stringify(creep));
     this.memory.queue.shift();
     return false;
   }

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -21,11 +21,6 @@ Room.prototype.myHandleRoom = function() {
   this.memory.lastSeen = Game.time;
   this.memory.constructionSites = this.find(FIND_CONSTRUCTION_SITES);
 
-  // TODO Fix for after `delete Memory.rooms`
-  if (!this.memory.position || !this.memory.position.structure) {
-    this.setup();
-  }
-
   if (!this.memory.queue) {
     this.memory.queue = [];
   }
@@ -498,11 +493,13 @@ Room.prototype.executeRoom = function() {
     this.checkRoleToSpawn('repairer');
   }
 
-  this.handleLinks();
-  this.handleObserver();
-  this.handlePowerSpawn();
-  this.handleTerminal();
-  this.handleNukeAttack();
+  if (this.memory.setup && this.memory.setup.completed) {
+    this.handleLinks();
+    this.handleObserver();
+    this.handlePowerSpawn();
+    this.handleTerminal();
+    this.handleNukeAttack();
+  }
   this.spawnCheckForCreate();
   this.handleMarket();
   brain.stats.addRoom(this.name, cpuUsed);

--- a/src/prototype_room_wallsetter.js
+++ b/src/prototype_room_wallsetter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Room.prototype.buildBlockers = function() {
-  //   this.log('buildBlockers: ' + this.memory.controllerLevel.buildBlockersInterval);
+  this.debugLog('baseBuilding', 'buildBlockers: ' + this.memory.controllerLevel.buildBlockersInterval);
 
   const spawns = this.findPropertyFilter(FIND_MY_STRUCTURES, 'structureType', [STRUCTURE_SPAWN]);
   if (spawns.length === 0) {

--- a/src/role_defender.js
+++ b/src/role_defender.js
@@ -16,7 +16,7 @@ roles.defender.settings = {
     1: [2, 1, 1],
     8: [4, 1, 1],
   },
-  fillTough: true,
+  // fillTough: true,
 };
 
 roles.defender.action = function(creep) {
@@ -48,6 +48,7 @@ roles.defender.preMove = function(creep) {
   creep.selfHeal();
   const target = creep.findClosestEnemy();
   if (target !== null) {
+    creep.creepLog(`preMove foundClosestEnemy ${target}`);
     creep.handleDefender();
     return true;
   }

--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -22,6 +22,11 @@ roles.harvester.settings = {
   layoutString: 'MWC',
   amount: {
     1: [2, 1, 1],
+    2: {
+      0: [2, 1, 1],
+      550: [4, 3, 1],
+      750: [2, 1, 1],
+    },
   },
   maxLayoutAmount: 6,
 };
@@ -44,6 +49,7 @@ roles.harvester.buildRoad = true;
 roles.harvester.boostActions = ['capacity'];
 
 roles.harvester.preMove = function(creep, directions) {
+  creep.creepLog(`preMove`);
   if (!creep.room.storage || !creep.room.storage.my || creep.room.memory.misplacedSpawn || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
     creep.harvesterBeforeStorage();
     creep.memory.routing.reached = true;
@@ -115,11 +121,12 @@ roles.harvester.preMove = function(creep, directions) {
 };
 
 roles.harvester.action = function(creep) {
+  creep.creepLog(`action`);
   if (!creep.memory.routing.targetId) {
     creep.memory.routing.targetId = 'harvester';
   }
 
-  if (!creep.room.storage || !creep.room.storage.my || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
+  if (!creep.room.storage || !creep.room.storage.my || creep.room.memory.misplacedSpawn || (creep.room.storage.store.energy + creep.carry.energy) < config.creep.energyFromStorageThreshold) {
     creep.harvesterBeforeStorage();
     creep.memory.routing.reached = false;
     return true;

--- a/src/role_planer.js
+++ b/src/role_planer.js
@@ -12,6 +12,7 @@ roles.planer = {};
 roles.planer.settings = {
   layoutString: 'MCW',
   amount: [2, 1, 1],
+  maxLayoutAmount: 20,
 };
 
 roles.planer.action = function(creep) {

--- a/src/role_repairer.js
+++ b/src/role_repairer.js
@@ -19,10 +19,23 @@ roles.repairer.settings = {
 
 roles.repairer.boostActions = ['repair'];
 
+roles.repairer.preMove = function(creep, directions) {
+  if (creep.memory.routing && creep.memory.routing.targetId) {
+    if (Game.getObjectById(creep.memory.routing.targetId) === null) {
+      creep.creepLog('target does not exist anymore');
+      delete creep.memory.routing.targetId;
+      roles.repairer.action(creep);
+      return true;
+    }
+  }
+};
+
 roles.repairer.action = function(creep) {
   creep.setNextSpawn();
   creep.spawnReplacement(1);
+  creep.creepLog('action');
   creep.pickupEnergy();
+  creep.creepLog('action after pickupEnergy');
   if (!creep.memory.move_wait) {
     creep.memory.move_wait = 0;
   }

--- a/src/role_scout.js
+++ b/src/role_scout.js
@@ -171,7 +171,7 @@ roles.scout.action = function(creep) {
       return false;
     }
 
-    if (creep.memory.last && creep.memory.last.pos3 && creep.pos.roomName !== creep.memory.last.pos3.roomName) {
+    if (creep.isStuck()) {
       creep.moveTo(25, 25);
       return true;
     }
@@ -197,7 +197,7 @@ roles.scout.action = function(creep) {
       creep.memory.stuck = 0;
     }
 
-    if (search.path.length === 0) {
+    if (search.path.length === 0 || search.incomplete) {
       creep.say('hello', true);
       //       creep.log(creep.pos + ' ' + targetPosObject + ' ' + JSON.stringify(search));
       if (creep.isStuck() && creep.pos.isBorder(-1)) {
@@ -211,13 +211,16 @@ roles.scout.action = function(creep) {
       // if (search.path.length > 0) {
       // creep.move(creep.pos.getDirectionTo(search.path[0]));
       // } else {
-      creep.moveTo(targetPosObject, {
-        ignoreCreeps: true,
-        costCallback: creep.room.getCostMatrixCallback(),
-      });
+      creep.creepLog(`scout.action no search targetPosObject ${JSON.stringify(targetPosObject)}`);
+      // creep.moveTo(targetPosObject, {
+      //   ignoreCreeps: true,
+      //   costCallback: creep.room.getCostMatrixCallback(),
+      // });
+      creep.moveTo(targetPosObject);
       // }
       return true;
     }
+    creep.creepLog(`scout.action search ${JSON.stringify(search)}`);
     creep.say(creep.pos.getDirectionTo(search.path[0]));
     creep.move(creep.pos.getDirectionTo(search.path[0]));
   };

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -103,23 +103,18 @@ if (config.visualizer.enabled) {
         if (room.memory.position) {
           const creeps = room.memory.position.creep;
           for (const positionName of Object.keys(creeps)) {
-            if (creeps[positionName]) {
-              if (creeps[positionName].x || creeps[positionName].y) {
-                let text = positionName.substr(0, 1);
-                const target = Game.getObjectById(positionName);
-                if (target) {
-                  if (target.structureType) {
-                    text = target.structureType.substr(0, 1);
-                  } else {
-                    text = 's'; // source
-                  }
-                }
-                this.drawPosition(rv, creeps[positionName], text, 'yellow');
+            let text = positionName.substr(0, 1);
+            const target = Game.getObjectById(positionName);
+            if (target) {
+              if (target.structureType) {
+                text = target.structureType.substr(0, 1);
               } else {
-                const text = positionName.substr(0, 1); // always 't'
-                for (const towerfiller of creeps[positionName]) {
-                  this.drawPosition(rv, towerfiller, text, 'yellow');
-                }
+                text = 's'; // source
+              }
+            }
+            for (const creep of creeps[positionName]) {
+              if (creep) {
+                this.drawPosition(rv, creep, text, 'yellow');
               }
             }
           }
@@ -133,9 +128,23 @@ if (config.visualizer.enabled) {
       if (cm) {
         for (let x = 0; x < 50; ++x) {
           for (let y = 0; y < 50; ++y) {
+            let fill = '#00FF00';
+            const value = cm.get(x, y);
+            const calculated = Math.min(255, 5 * value);
+            if (config.visualizer.showCostMatrixValues) {
+              this.drawPosition(rv, new RoomPosition(x, y, roomName), value, 'blue');
+            }
+
+            if (value) {
+              fill = `#${(0.8 * calculated).toString(16)}0A0A`;
+            }
+            let opacity = 0;
+            if (value > 0) {
+              opacity = 0.15 + 0.3 * (calculated / 255);
+            }
             rv.rect(x - 0.5, y - 0.5, 1, 1, {
-              fill: 'pink',
-              opacity: Math.pow(cm.get(x, y) / 255, 1 / 4),
+              fill: fill,
+              opacity: opacity,
             });
           }
         }
@@ -228,6 +237,9 @@ global.visualizer.myRoomDatasDraw = function(roomName) {
     for (let id = 0; id < 2; id++) {
       lowest = lowestInQueue[id];
       lines.push({label: `Lowest ${labels[id]}: ${lowest.role} --> ${(lowest.routing && lowest.routing.targetRoom) || '?'} | TTL: ${lowest.ttl || '?'}`});
+    }
+    for (const item of room.memory.queue) {
+      lines.push({label: `- ${item.role} --> ${(item.routing && item.routing.targetRoom) || '?'} | TTL: ${item.ttl || '?'}`});
     }
   }
   let y = 0;

--- a/utils/testHelpers.js
+++ b/utils/testHelpers.js
@@ -1,0 +1,248 @@
+const fs = require('fs');
+const rimraf = require('rimraf');
+const path = require('path');
+const ncp = require('ncp');
+const lib = require('@screeps/launcher/lib/index');
+const _ = require('lodash');
+const {ScreepsAPI} = require('screeps-api');
+
+const dir = 'tmp-test-server';
+const port = 21025;
+
+/**
+ * followLog method
+ *
+ * Connects to the api and reads and prints the console log, if messages
+ * are available
+ *
+ * @return {undefined}
+ */
+async function followLog(rooms, logConsole, statusUpdater) {
+  for (const room of rooms) {
+    const api = new ScreepsAPI({
+      email: room,
+      password: 'tooangel',
+      protocol: 'http',
+      hostname: '127.0.0.1',
+      port: port,
+      path: '/',
+    });
+
+    await api.auth();
+
+    api.socket.connect();
+    api.socket.on('connected', ()=> {});
+    api.socket.on('auth', (event)=> {});
+    api.socket.subscribe('console', logConsole(room));
+    api.socket.subscribe('room:' + room, statusUpdater);
+  }
+}
+module.exports.followLog = followLog;
+
+/**
+ * sets password for TooAngel user
+ *
+ * @param {string} line
+ * @param {object} socket
+ * @return {boolean}
+ */
+const setPassword = function(line, socket, rooms, roomsSeen, playerRoom) {
+  for (const room of rooms) {
+    if (line.startsWith(`'User ${room} with bot AI "screeps-bot-tooangel" spawned in ${room}'`)) {
+      roomsSeen[room] = true;
+      console.log(`> Set password for ${room}`);
+      /* eslint max-len: ["error", 1300] */
+      socket.write(`storage.db.users.update({username: '${room}'}, {$set: {password: '70dbaf0462458b31ff9b3d184d06824d1de01f6ad59cae7b5b9c01a8b530875ac502c46985b63f0c147cf59936ac1be302edc532abc38236ab59efecb3ec7f64fad7e4544c1c5a5294a8f6f45204deeb009a31dd6e81e879cfb3b7e63f3d937f412734b1a3fa7bc04bf3634d6bc6503bb0068c3f6b44f3a84b5fa421690a7399799e3be95278381ae2ac158c27f31eef99db1f21e75d285802cda983cd8a73a8a85d03ba45dcc7eb2b2ada362887df10bf74cdcca47f911147fd0946fb5119c888f048000044072dcc29b1c428b40b805cadeee7b3afc1e9d9d546c2a878ff8df9fcf805a28cc8b6e4b78051f0adb33642f1097bf0a189f388860302df6173b8e7955a35b278655df2d7615b54da6c63dc501c7914d726bea325c2225f343dff0068ac42300661664ee5611eb623e1efa379f571d46ba6a0e13a9e3e9c5bb7a772b685258f768216a830c5e9af3685898d98a9935cca2ba5efb5e1e4a9f2745c53bff318bda3e376bcd06b06d87a55045a76a1982f6e3b9fb77d39c2ff5c09c76989d1c779655bc2acdf55879b68f6155d14c26bdca3af5c7fd6de9926dbc091da280e6f7e3d727fa68c89aa8ac25b5e50bd14bf2dbcd452975710ef4b8d61a81c8f6ef2d5584eacfcb1ab4202860320f03313d23076a3b3e085af5f0a9e010ddb0ad5af57ed0db459db0d29aa2bcbcd64588d4c54d0c5265bf82f31349d9456', salt: '7eeb813417828682419582da8f997dea3e848ce8293e68b2dbb2f334b1f8949f'}})\r\n`);
+      if (process.env.STEAM_ID && room === playerRoom) {
+        console.log(`> Set steam id for ${room}`);
+        socket.write(`storage.db.users.update({username: '${room}'}, {$set: {steam: {id: '${process.env.STEAM_ID}'}}})\r\n`);
+      }
+      return true;
+    }
+  }
+  return false;
+};
+module.exports.setPassword = setPassword;
+
+/**
+ * sleep method
+ *
+ * Helper method to sleep for amount of seconds.
+ * @param {number} seconds Amount of seconds to sleep
+ * @return {object}
+ */
+function sleep(seconds) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+module.exports.sleep = sleep;
+
+async function initServer() {
+  if (fs.existsSync(dir)) {
+    rimraf.sync(dir);
+  }
+  fs.mkdirSync(dir, 0744);
+  await new Promise(function(resolve) {
+    ncp(path.resolve(__dirname, '../node_modules/@screeps/launcher/init_dist'), dir, (e) => {
+      resolve();
+    });
+  });
+  var configFilename = path.resolve(dir, '.screepsrc');
+  var config = fs.readFileSync(configFilename, {encoding: 'utf8'});
+  config = config.replace(/{{STEAM_KEY}}/, process.env.STEAM_API_KEY);
+  fs.writeFileSync(configFilename, config);
+  fs.chmodSync(path.resolve(dir, 'node_modules/.hooks/install'), '755');
+  fs.chmodSync(path.resolve(dir, 'node_modules/.hooks/uninstall'), '755');
+
+  await new Promise(function(resolve) {
+    fs.copyFile('test-files/mods.json', `${dir}/mods.json`, (err) => {
+      if (err) throw err;
+      resolve();
+    });
+  });
+  try {
+      fs.writeFileSync(path.resolve(dir, 'package.json'), JSON.stringify({
+          name: 'my-screeps-world',
+          version: '0.0.1',
+          private: true
+      }, undefined, '  '), {encoding: 'utf8', flag: 'wx'});
+  }
+  catch(e) {}
+}
+module.exports.initServer = initServer;
+
+/**
+ * startServer method
+ *
+ * Starts the private server
+ * @return {object}
+ */
+async function startServer() {
+  process.chdir(dir);
+  return lib.start({}, process.stdout);
+}
+module.exports.startServer = startServer;
+
+/**
+ * logs event
+ *
+ * @param {object} event
+ */
+const logConsole = function(room) {
+  return (event) => {
+    if (event.channel !== 'console') {
+      console.log(room, `logConsole channel not console: ${JSON.stringify(event)}`);
+    }
+    if (event.type !== 'user') {
+      console.log(room, `logConsole channel not user: ${JSON.stringify(event)}`);
+    }
+    if (!event.data) {
+      console.log(room, `logConsole no data: ${JSON.stringify(event)}`);
+      return;
+    }
+    if (event.data.error) {
+      console.log(room, event.data.error);
+    }
+    if (event.data.messages) {
+      if (event.data.messages.results.length > 0) {
+        console.log(room, `logConsole event.data.messages.results: ${JSON.stringify(event.data.messages.results)}`);
+      }
+
+      if (event.data.messages.log.length > 0) {
+        for (let logIndex = 0; logIndex < event.data.messages.log.length; logIndex++) {
+          console.log(room, event.data.messages.log[logIndex]);
+        }
+      }
+    }
+  };
+};
+module.exports.logConsole = logConsole;
+
+
+
+/**
+ * spawns TooAngel Bot
+ *
+ * @param {string} line
+ * @param {object} socket
+ * @return {boolean}
+ */
+const spawnBots = async function(line, socket, rooms, players, tickDuration) {
+  if (line.startsWith(`Screeps server v`)) {
+    console.log(`> system.resetAllData()`);
+    socket.write(`system.resetAllData()\r\n`);
+    await sleep(5);
+    console.log(`> system.pauseSimulation()`);
+    socket.write(`system.pauseSimulation()\r\n`);
+    await sleep(5);
+    console.log(`> utils.setTickRate(${tickDuration})`);
+    socket.write(`utils.setTickRate(${tickDuration})\r\n`);
+    for (const room of rooms) {
+      console.log('> Spawn bot ' + room + ' as TooAngel');
+      socket.write(`bots.spawn('screeps-bot-tooangel', '${room}', {username: '${room}', cpu: 100, gcl: 1, x: ${players[room].x}, y: ${players[room].y}})\r\n`);
+      await sleep(1);
+    }
+    return true;
+  }
+  return false;
+};
+module.exports.spawnBots = spawnBots;
+
+const filter = {
+  controller: (o) => {
+    if (o && o.type) {
+      return o.type === 'controller';
+    }
+    return false;
+  },
+  creeps: (o) => {
+    if (o && o.type) {
+      return o.type === 'creep';
+    }
+    return false;
+  },
+  structures: (o) => {
+    if (o && o.type) {
+      return o.type === 'spawn' || o.type == 'extension';
+    }
+    return false;
+  },
+};
+
+const helpers = {
+  initControllerID: function(event, status, controllerRooms) {
+    if (status[event.id].controller === null) {
+      status[event.id].controller = _.filter(event.data.objects, filter.controller)[0];
+      status[event.id].controller = status[event.id].controller._id;
+      controllerRooms[status[event.id].controller] = event.id;
+    }
+  },
+  updateCreeps: function(event, status) {
+    const creeps = _.filter(event.data.objects, filter.creeps);
+    if (_.size(creeps) > 0) {
+      status[event.id].creeps += _.size(creeps);
+    }
+  },
+  updateStructures: function(event, status) {
+    const structures = _.filter(event.data.objects, filter.structures);
+    if (_.size(structures) > 0) {
+      status[event.id].structures += _.size(structures);
+    }
+  },
+  updateController: function(event, status, controllerRooms) {
+    const controllers = _.pick(event.data.objects, Object.keys(controllerRooms));
+    for (const controllerId of Object.keys(controllers)) {
+      const controller = controllers[controllerId];
+      const roomName = controllerRooms[controllerId];
+      if (status[roomName] === undefined) {
+        continue;
+      }
+      if (controller.progress >= 0) {
+        status[roomName].progress = controller.progress;
+      }
+      if (controller.level >= 0) {
+        status[roomName].level = controller.level;
+      }
+    }
+  },
+};
+module.exports.helpers = helpers;


### PR DESCRIPTION
- Tests uses milestones which are checked on each tick. A `tick` value
describes the latest tick where the check needs to be successful, the
failed rooms as well as the tick when the milestone was reached is
logged.
- Overall improve the test structure and log output
  - Use a class for the test logic
  - When `STEAM_ID` is provided as env variable, the user is added to
one of the rooms
  - Catch SIGINT and print out the status and milestones

- Improve room layout:
  - Use the position with the least amount of free spaces as pathStart,
to not mess up with the filler area
  - Introduce `updateCostMatrix` function to create a costMatrix based
on the positions, this separates room setup from costMatrix generation
  - Resetup a room on RCL 2, because the first could have failed
  - Perturb path based on @sparr #457 Pull Request
  - Avoid sources to have less carry confusion close to sources
  - Move terminal to mineral
- Add brain debuglog
- Use `moveToMy` with simplyfied costmatrix
- Improve `isStuck` with the last 5 positions and at least 3 needs to be
equal
- Improve reserver logic
- Handle invader core (somehow)
- Fix harvester and cary size, less move parts because moving on roads
- build road only on path
- Sourcer adds carry not if in queue
- Fix reserver level
- Build road also with fatigue
- check on path with direct null comparison

Fixes #497
Fixes #457
Fixes #486