### PR TITLE
Fixes harvester bug for high gcl and energy <= 350

### DIFF
--- a/src/config_brain_stats.js
+++ b/src/config_brain_stats.js
@@ -62,6 +62,7 @@ brain.stats.add = function(path, newContent) {
     current = current[item];
   }
 
+  // Redundant _.merge automatically alters first object
   current = _.merge(current, newContent);
   return true;
 };

--- a/src/prototype_creep_resources.js
+++ b/src/prototype_creep_resources.js
@@ -726,9 +726,18 @@ Creep.prototype.construct = function() {
 };
 
 Creep.prototype.getTransferTargetStructure = function() {
-  const structure = this.pos.findClosestStructureWithMissingEnergyByRange(
+  let structure = this.pos.findClosestStructureWithMissingEnergyByRange(
     (object) => object.structureType !== STRUCTURE_STORAGE,
   );
+  // Harvester should always prefer Spawn and Extensions
+  if (this.memory.role === 'harvester') {
+    const structureSpawnExtension = this.pos.findClosestStructureWithMissingEnergyByRange(
+      (object) => (object.structureType === STRUCTURE_SPAWN || object.structureType === STRUCTURE_EXTENSION),
+    );
+    if (structureSpawnExtension !== null) {
+      structure = structureSpawnExtension;
+    }
+  }
   if (structure === null) {
     if (this.room.storage && this.room.storage.my && this.memory.role !== 'planer') {
       this.memory.target = this.room.storage.id;

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -211,7 +211,14 @@ Room.prototype.getPartsStringDatas = function(parts, energyAvailable) {
 Room.prototype.getSettings = function(creep) {
   const role = creep.role;
   const updateSettings = roles[role].updateSettings && roles[role].updateSettings(this, creep);
-  const settings = _.merge(roles[role].settings, updateSettings);
+  if (config.debug.spawn) {
+    this.log(`getSettings updateSettings: ${JSON.stringify(updateSettings)}`);
+    this.log(`getSettings roles[role].settings: ${JSON.stringify(roles[role].settings)}`);
+  }
+  const settings = _.merge({}, roles[role].settings, updateSettings);
+  if (config.debug.spawn) {
+    this.log(`getSettings settings: ${JSON.stringify(settings)}`);
+  }
   if (!settings) {
     this.log('try to spawn ', role, ' but settings are not done. Abort spawn');
     return;
@@ -319,8 +326,14 @@ Room.prototype.getPartConfig = function(creep) {
     fillTough} = settings;
   let layoutString = settings.layoutString;
   const maxBodyLength = this.getPartConfigMaxBodyLength();
+  if (config.debug.spawn) {
+    this.log(`getPartConfig settings: ${JSON.stringify(settings)}`);
+  }
 
   const prefix = this.getPartsStringDatas(prefixString, energyAvailable);
+  if (config.debug.spawn) {
+    this.log(`getPartConfig prefixString: ${JSON.stringify(prefixString)} prefix: ${JSON.stringify(prefix)} energyAvailable: ${JSON.stringify(energyAvailable)}`);
+  }
   if (prefix.fail) {
     return false;
   }
@@ -329,6 +342,9 @@ Room.prototype.getPartConfig = function(creep) {
 
   layoutString = this.applyAmount(layoutString, amount);
   const layout = this.getPartsStringDatas(layoutString, energyAvailable);
+  if (config.debug.spawn) {
+    this.log(`getPartConfig layoutString: ${JSON.stringify(layoutString)} prefix: ${JSON.stringify(layout)} energyAvailable: ${JSON.stringify(energyAvailable)}`);
+  }
   if (layout.fail || layout.null) {
     return false;
   }
@@ -348,6 +364,9 @@ Room.prototype.getPartConfig = function(creep) {
   if (!sufix.fail && !sufix.null) {
     parts = parts.concat(sufix.parts || []);
     energyAvailable -= sufix.cost || 0;
+  }
+  if (config.debug.spawn) {
+    this.log(`getPartConfig sufixString: ${JSON.stringify(sufixString)} sufix: ${JSON.stringify(sufix)} energyAvailable: ${JSON.stringify(energyAvailable)}`);
   }
 
   if (fillTough && parts.length < MAX_CREEP_SIZE) {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -71,7 +71,8 @@ Room.prototype.handleLinks = function() {
   }
 
   const linkStorage = this.getLinkStorage();
-  if (!linkStorage) {
+  // Only send energy if linkStorage is set and free capacity is higher or equals than 400 Energy
+  if (!linkStorage || linkStorage.store.getFreeCapacity(RESOURCE_ENERGY) < 400) {
     return;
   }
 

--- a/src/role_harvester.js
+++ b/src/role_harvester.js
@@ -31,19 +31,7 @@ roles.harvester.settings = {
   maxLayoutAmount: 6,
 };
 roles.harvester.updateSettings = function(room) {
-  // If the energy average is lower than 350 for a longer period at least one low level harvester will be spawned.
-  // Fix for the following problem:
-  // - no room is able to send a nextroomer
-  // - all creeps are dead
-  // - energyAvailable is higher than 300 but lower than 350 for a longer time
-  if (room.memory.energyStats.average <= 350) {
-    // Layoutcost minimum: layout 250 -> 250
-    return {
-      layoutString: 'MWC',
-      amount: [2, 1, 1],
-      maxLayoutAmount: 6,
-    };
-  } else if (room.storage && room.storage.my && room.storage.store.energy > config.creep.energyFromStorageThreshold && room.energyAvailable > 350 && !room.memory.misplacedSpawn) {
+  if (room.storage && room.storage.my && room.storage.store.energy > config.creep.energyFromStorageThreshold && room.energyAvailable >= 350 && !room.memory.misplacedSpawn) {
     // Layoutcost minimum: prefix 250 + layout 100 -> 350
     return {
       prefixString: 'WMC',


### PR DESCRIPTION
Fixed creep builder updateSettings function. (lodash merge)
Harvester prefers empty spawns and extensions before anything else.
Added logging to config.debug.spawn.
Cleared unnecessary stuff from harvester.updateSettings.

Fixes #585