### PR TITLE
Fix storage filler link position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screeps-bot-tooangel",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "src/main.js",
   "screeps_bot": true,

--- a/src/config.js
+++ b/src/config.js
@@ -249,7 +249,7 @@ global.config = {
     structureAvoid: 0xFF,
     creepAvoid: 0xFF,
     wallThickness: 1,
-    version: 20,
+    version: 21,
   },
 
   terminal: {

--- a/src/prototype_room_init.js
+++ b/src/prototype_room_init.js
@@ -68,7 +68,7 @@ Room.prototype.setFillerArea = function(storagePos, route) {
   }
 
   const linkStoragePos = fillerNearPositions.shift();
-  this.setPosition(STRUCTURE_LINK, linkStoragePos);
+  this.setPosition(STRUCTURE_LINK, linkStoragePos, config.layout.structureAvoid, 'structure', true);
 
   try {
     this.setPosition(STRUCTURE_POWER_SPAWN, fillerNearPositions.shift());
@@ -162,7 +162,7 @@ Room.prototype.updatePosition = function() {
   }
 };
 
-Room.prototype.setPosition = function(type, pos, value = config.layout.structureAvoid, positionType = 'structure') {
+Room.prototype.setPosition = function(type, pos, value = config.layout.structureAvoid, positionType = 'structure', firstStructure = false) {
   const costMatrix = this.getMemoryCostMatrix();
   if (!this.memory.position[positionType]) {
     this.memory.position[positionType] = {};
@@ -170,7 +170,11 @@ Room.prototype.setPosition = function(type, pos, value = config.layout.structure
   if (!this.memory.position[positionType][type]) {
     this.memory.position[positionType][type] = [];
   }
-  this.memory.position[positionType][type].push(pos);
+  if (firstStructure) {
+    this.memory.position[positionType][type].unshift(pos);
+  } else {
+    this.memory.position[positionType][type].push(pos);
+  }
   this.debugLog('baseBuilding', `Increasing ${pos} ${type} ${positionType} with ${value}`);
   this.increaseCostMatrixValue(costMatrix, pos, value);
   this.setMemoryCostMatrix(costMatrix);


### PR DESCRIPTION
The link with is next to filler needs to be the first in the position
list. Especially the link transfer logic relies on that fact.
Update bot version so that a new version is released for the private
server.
!! Updating the room layout version, this will recalculate the rooms and
might lead to a room rebuild. The only intended change is the position
of the storage link in `memory.position.structure.link`.

Fixes #582