### PR TITLE
Fix only spawn harvester bug

### DIFF
--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -65,10 +65,10 @@ Room.prototype.isSameCreep = function(first, second) {
   if (first.role !== second.role) {
     return false;
   }
-  if (first.routing.targetRoom !== second.routing.targetRoom) {
+  if (first.routing.targetRoom && second.routing.targetRoom && first.routing.targetRoom !== second.routing.targetRoom) {
     return false;
   }
-  if (first.routing.targetId !== second.routing.targetId) {
+  if (first.routing.targetId && second.routing.targetId && first.routing.targetId !== second.routing.targetId) {
     return false;
   }
   return true;


### PR DESCRIPTION
The harvester spawns without `targetId` but it is set in the later
process. When comparing creeps it needs to check for the 'wildcard'
`targetId` to match harvesters.