### PR TITLE
Bugfix nextroomers not being called and creep builder

### DIFF
--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -302,7 +302,7 @@ Room.prototype.getPartConfig = function(creep) {
     sufixString,
     fillTough} = settings;
   let layoutString = settings.layoutString;
-  const maxBodyLength = this.getPartConfigMaxBodyLength();
+  const maxBodyLength = this.getPartConfigMaxBodyLength(prefixString, sufixString);
 
   const prefix = this.getPartsStringDatas(prefixString, energyAvailable);
   if (prefix.fail) {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -558,28 +558,23 @@ const checkForRoute = function(room, roomOther) {
 };
 
 Room.prototype.reviveMyNowHelperValid = function(helperRoom) {
+  let valid = false;
+
   if (helperRoom.isStruggeling()) {
     this.debugLog('revive', `No nextroomer is struggeling ${helperRoom.name}`);
-    return false;
-  }
-  // When close before downgrading, just send nextroomers
-  // TODO replace 1500 with CREEP_LIFE_TIME
-  if (this.controller.ticksToDowngrade > 1500 && !helperRoom.isHealthy()) {
+  } else if (this.controller.ticksToDowngrade > 1500 && !helperRoom.isHealthy()) {
+    // When close before downgrading, just send nextroomers
+    // TODO replace 1500 with CREEP_LIFE_TIME
     this.debugLog('revive', `No nextroomer not healthy ${helperRoom.name} ${helperRoom.storage.store.energy}`);
-    return false;
-  }
-  const distance = Game.map.getRoomLinearDistance(this.name, helperRoom.name);
-  if (distance > config.nextRoom.maxDistance) {
+  } else if (Game.map.getRoomLinearDistance(this.name, helperRoom.name) > config.nextRoom.maxDistance) {
     this.debugLog('revive', `Too far ${helperRoom.name}`);
-    return false;
-  }
-
-  if (checkForRoute(this, helperRoom)) {
+  } else if (checkForRoute(this, helperRoom)) {
     this.debugLog('revive', `No nextroomer checkForRoute no route to ${helperRoom.name}`);
-    return false;
+  } else {
+    valid = true;
   }
 
-  return true;
+  return valid;
 };
 
 Room.prototype.reviveMyNow = function() {

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -578,6 +578,8 @@ Room.prototype.reviveMyNowHelperValid = function(helperRoom) {
     this.debugLog('revive', `No nextroomer checkForRoute no route to ${helperRoom.name}`);
     return false;
   }
+
+  return true;
 };
 
 Room.prototype.reviveMyNow = function() {


### PR DESCRIPTION
Have been playing with this bot for the last few days and noticed/fixed a couple bugs that popped up. 

- The creepbuilder was frequently returning `spawnCreateCreep body too long` because the `getPartConfigMaxBodyLength` was not properly being passed the prefix and suffix strings

- Nextroomers were not being called, nor rooms revived because `reviveMyNowHelperValid` previously never returned true, meaning the following code block would always execute and it never got to the `helperRoom.checkRoleToSpawn('nextroomer', ...)` line

```
    if (!this.reviveMyNowHelperValid(helperRoom)) {
      continue;
    }
```