### PR TITLE
[SEVERE]Fix getEnergyFromStorage code changed by wilken which cause if room have a storage, all creeps brain-down, and you lose the battle soon.

### DIFF
--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -169,7 +169,7 @@ Creep.prototype.getEnergyFromStorage = function() {
     return false;
   }
 
-  if (this.room.isStruggeling()) {
+  if (this.room.isStruggling()) {
     return false;
   }
 


### PR DESCRIPTION
@TooAngel I cannot say there be 0 possibility that it be a bug, but I really think it possibly be a hacking-attack to this repo. 

please review as soon as possible, thanks. 

wow when room have a storage and room is not misplacedSpawn, it will call a non-exist function, cause error, thus all creeps just brain-down and cannot extract any energy. 

REALLY NICE HACKING FOR KILLING ROOM-LEVEL4+ PLAYERS, INCLUDING ME THIS AFTERNOON TODAY.