### PR TITLE
[BUG]fix a debug log who would cause error

### DIFF
--- a/src/diplomacy.js
+++ b/src/diplomacy.js
@@ -50,7 +50,7 @@ module.exports.checkPlayers = checkPlayers;
 
 const findRoomPairs = function(player) {
   for (const roomName of Object.keys(player.rooms).sort(() => 0.5 - Math.random())) {
-    debugLog('diplomacy', `findRoomPairs: room ${roomName} data: ${JSON.stringify(global.data.rooms[roomName])}`);
+    debugLog('diplomacy', `findRoomPairs: room ${roomName}`);
     const minRCL = ((global.data.rooms[roomName] || {}).controller || {}).level || 8;
     const range = 7;
     const myRoomName = getMyRoomWithinRange(roomName, range, minRCL);


### PR DESCRIPTION
fix a debug log who would cause error like:

Error: Could not find an object with ID 63174ac39538317abc9be996
    at data (:51004:15)
    at Object.get [as name] (eval at exports.defineGameObjectProperties (:586:9), :7:60)
    at Object.exports.defineGameObjectProperties.obj.toJSON (:610:29)
    at JSON.stringify ()
    at findRoomPairs (diplomacy:53:73)
    at handleRetaliation (diplomacy:121:20)
    at addToReputation (diplomacy:167:7)
    at Object.Room.handleReputation (prototype_room_my:344:7)
    at Object.Room.executeRoomHandleHostiles (prototype_room_my:488:8)
    at Object.Room.executeRoom (prototype_room_my:508:8)