### PR TITLE
[LOGIC REFINE]prevent sending useless reservers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4427,9 +4427,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -195,6 +195,11 @@ Room.prototype.checkRoleToSpawn = function(role, amount, targetId, targetRoom, l
   if (this.inQueue(creepMemory) || this.inRoom(creepMemory, amount)) {
     return false;
   }
+  if (targetRoom !== base && typeof Game.map.getRoomStatus(targetRoom) !== 'undefined' && typeof Game.map.getRoomStatus(base) !== 'undefined') {
+    if (Game.map.getRoomStatus(targetRoom).status !== Game.map.getRoomStatus(base).status) {
+      return false;
+    }
+  }
   return this.memory.queue.push(creepMemory);
 };
 


### PR DESCRIPTION
According to https://docs.screeps.com/start-areas.html
> The sector is completely separated from the outer world with a blind, indestructible wall preventing outside players from entering it. Getting inside a Novice Area is possible only by placing there your initial spawn directly.

It's impossible to travel between rooms with different status, so sending reservers is just wasting energy.  
Now check before sending them.

Updated Nov 6, 2022:

In a reserved room in a novice area, and next to normal area, walls exist but cannot be destroyed. Reservers shouldn't call structurers if the structure is not able to be destroyed.