### PR TITLE
Consider the room with a tower not blocked if it was unclaimed by oneself

### DIFF
--- a/src/prototype_room_external.js
+++ b/src/prototype_room_external.js
@@ -399,6 +399,9 @@ Room.prototype.checkBlockedPath = function() {
         if (structure.structureType === STRUCTURE_INVADER_CORE) {
           continue;
         }
+        if (structure.structureType === STRUCTURE_TOWER && structure.my) {
+          continue;
+        }
         this.log(`Path ${pathName} blocked on ${pos} due to ${structure.structureType}`);
         return true;
       }


### PR DESCRIPTION
The creeps shouldn't consider the room with tower blocked as long as its owner is oneself. This could be useful in following situation:

Room A | Room B | Room C

If you have room C as your base room, and you claimed room B, built a tower in room B.  
And at some time you want room A, but you only get 2 GCL, then room B must be unclaimed.  
If you forget to destroy the tower in room B, the bot will maybe never reach room A (without my changes, if no other routes)!

Then consider the tower's owner. Even if a room is not owned by the user, the tower could be harmless.