### PR TITLE
small fixes and improvements

### DIFF
--- a/src/brain_memory.js
+++ b/src/brain_memory.js
@@ -58,11 +58,11 @@ function handleUnexpectedDeadCreeps(name, creepMemory) {
     console.log(`${Game.time} ${name} handleUnexpectedDeadCreeps no creepMemory.room creepMemory: ${JSON.stringify(creepMemory)} data: ${JSON.stringify(global.data.creeps[name])}`);
   }
 
-  debugLog(`${Game.time} ${creepMemory.room} ${name} memory hostile: ${data.hostileCreepCount}`);
   if (data.hostileCreepCount > 0) {
+    debugLog(`${Game.time} ${creepMemory.room} ${name} memory hostile: ${data.hostileCreepCount}`);
     debugLog('brain', `${creepMemory.room} ${name} Not in Game.creeps with hostiles lived ${Game.time - creepMemory.born} hostiles: ${data.hostileCreepCount} - I guess killed by hostile`); // eslint-disable-line max-len
   } else {
-    console.log(`${Game.time} ${creepMemory.room} ${name} Not in Game.creeps without hostiles lived ${Game.time - creepMemory.born} hostiles: ${data.hostileCreepCount}`); // eslint-disable-line max-len
+    console.log(`${Game.time} ${creepMemory.room} ${name} Not in Game.creeps without hostiles lived ${Game.time - creepMemory.born}`); // eslint-disable-line max-len
   }
 
   if (Game.time - creepMemory.born < 20) {
@@ -169,7 +169,9 @@ function cleanRooms() {
         delete Memory.rooms[name];
       }
       if (Memory.myRooms.indexOf(name) < 0) {
-        console.log(Game.time, `Deleting ${name} from memory, no myRoom ${JSON.stringify(Memory.rooms[name])}`);
+        if (Object.keys(Memory.rooms[name]).length > 0) {
+          console.log(Game.time, `Deleting ${name} from memory, no myRoom ${JSON.stringify(Memory.rooms[name])}`);
+        }
         delete Memory.rooms[name];
       }
     }

--- a/src/config.js
+++ b/src/config.js
@@ -148,6 +148,8 @@ global.config = {
 
   commodities: {
     disabled: false,
+    minRCL: 7,
+    range: 6,
   },
 
   pixel: {

--- a/src/helper_findMyRooms.js
+++ b/src/helper_findMyRooms.js
@@ -20,6 +20,7 @@ function findRoomsWithinReach(room) {
   }
   return rooms;
 }
+
 module.exports.findRoomsWithinReach = findRoomsWithinReach;
 
 /**
@@ -35,6 +36,7 @@ function findMyRoomsSortByDistance(roomName) {
 
   return _.sortBy(Memory.myRooms, sortByDistance);
 }
+
 module.exports.findMyRoomsSortByDistance = findMyRoomsSortByDistance;
 
 /**
@@ -67,4 +69,5 @@ function getMyRoomWithinRange(roomName, range, minRCL) {
   }
   return false;
 }
+
 module.exports.getMyRoomWithinRange = getMyRoomWithinRange;

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -279,7 +279,6 @@ Creep.prototype.buildRoad = function() {
     constructionSites.length <= config.buildRoad.maxConstructionSitesRoom &&
     Object.keys(Game.constructionSites).length < config.buildRoad.maxConstructionSitesTotal &&
     this.memory.routing.pathPos >= 0
-  // && this.pos.inPath()
   ) {
     const returnCode = this.pos.createConstructionSite(STRUCTURE_ROAD);
     if (returnCode === OK) {
@@ -403,6 +402,11 @@ Creep.prototype.killPrevious = function(path) {
   return true;
 };
 
+/**
+ * respawn creep no mater what, copy of memory
+ *
+ * @return {number} in queue
+ */
 Creep.prototype.respawnMe = function() {
   const routing = {
     targetRoom: this.memory.routing.targetRoom,
@@ -416,7 +420,7 @@ Creep.prototype.respawnMe = function() {
     level: this.memory.level,
     routing: routing,
   };
-  Game.rooms[this.memory.base].memory.queue.push(spawn);
+  return Game.rooms[this.memory.base].memory.queue.push(spawn);
 };
 
 Creep.prototype.spawnReplacement = function(maxOfRole) {

--- a/src/prototype_creep_move.js
+++ b/src/prototype_creep_move.js
@@ -9,7 +9,7 @@
  * @param {boolean} withinRoom - Stays within the room
  * @return {object} - Response from PathFinder.search
  **/
-Creep.prototype.searchPath = function(target, range=1, withinRoom=false) {
+Creep.prototype.searchPath = function(target, range = 1, withinRoom = false) {
   let costMatrixCallback;
   if (this.room.memory.misplacedSpawn) {
     costMatrixCallback = this.room.getBasicCostMatrixCallback(withinRoom);
@@ -59,7 +59,7 @@ Creep.prototype.moveMy = function(target) {
  * @param {boolean} withinRoom - Stays within the room
  * @return {boolean|OK|ERR_TIRED} - Success of the execution
  **/
-Creep.prototype.moveToMy = function(target, range=1, withinRoom=false) {
+Creep.prototype.moveToMy = function(target, range = 1, withinRoom = false) {
   this.creepLog(`moveToMy(${target}, ${range}) pos: ${this.pos}`);
   if (this.fatigue > 0) {
     return true;
@@ -68,8 +68,13 @@ Creep.prototype.moveToMy = function(target, range=1, withinRoom=false) {
   const search = this.searchPath(target, range, withinRoom);
   // Fallback to moveTo when the path is incomplete and the creep is only switching positions
   if (search.path.length < 2 && search.incomplete) {
-    this.log(`moveToMy search.path too short ${JSON.stringify(search)} target: ${target}`);
-    return this.moveTo(target, {range: range});
+    if (this.memory.role === 'repairer') {
+      // repairer found energy behind a wall, can not pickup
+      return false;
+    } else {
+      this.log(`moveToMy search.path too short ${JSON.stringify(search)} target: ${target}`);
+      return this.moveTo(target, {range: range});
+    }
   }
   target = search.path[0] || target.pos || target;
 

--- a/src/prototype_creep_routing.js
+++ b/src/prototype_creep_routing.js
@@ -12,8 +12,16 @@ Creep.prototype.getRoute = function() {
   }
 
   let route = [];
+  let useHighWay = false;
+  switch (this.memory.role) {
+  case 'carry':
+  case 'claimer':
+  case 'nextroomer':
+    useHighWay = true;
+  }
+
   if (this.memory.base !== this.memory.routing.targetRoom) {
-    route = this.room.findRoute(this.memory.base, this.memory.routing.targetRoom);
+    route = this.room.findRoute(this.memory.base, this.memory.routing.targetRoom, useHighWay);
     if (route < 0) {
       route = this.room.findRoute(this.memory.base, this.memory.routing.targetRoom, true);
     }

--- a/src/prototype_room_costmatrix.js
+++ b/src/prototype_room_costmatrix.js
@@ -22,7 +22,7 @@ function updateCostMatrixFromPositions(room, costMatrix) {
       if (positionType === 'version') {
         continue;
       }
-      for (let i = 0; i<room.data.positions[positionType][type].length; i++) {
+      for (let i = 0; i < room.data.positions[positionType][type].length; i++) {
         const pos = room.data.positions[positionType][type][i];
         if (!pos) {
           room.log(`No pos for positionType: ${positionType} type: ${type} i: ${i}`);

--- a/src/prototype_room_creepbuilder.js
+++ b/src/prototype_room_creepbuilder.js
@@ -51,7 +51,7 @@ Room.prototype.spawnCheckForCreate = function() {
     this.memory.queue.shift();
     return false;
   }
-  creep.ttl = creep.ttl || config.creep.queueTtl;
+  creep.ttl = creep.ttl || Math.ceil(config.creep.queueTtl * _.size(CONTROLLER_DOWNGRADE) / this.controller.level);
   if (this.findSpawnsNotSpawning().length === 0) {
     creep.ttl--;
   }

--- a/src/prototype_room_defense.js
+++ b/src/prototype_room_defense.js
@@ -4,6 +4,9 @@ Room.prototype.findAttackCreeps = function(object) {
   if (object.owner.username === 'Source Keeper') {
     return false;
   }
+  if (friends.indexOf(object.owner.username) > -1) {
+    return false;
+  }
 
   for (const item of Object.keys(object.body)) {
     const part = object.body[item];

--- a/src/prototype_room_external.js
+++ b/src/prototype_room_external.js
@@ -271,7 +271,7 @@ Room.prototype.harvestCommodities = function() {
     return;
   }
   this.debugLog('commodities', `Commodities found ${JSON.stringify(deposits)}`);
-  const baseRoomName = getMyRoomWithinRange(this.name, 6, 6);
+  const baseRoomName = getMyRoomWithinRange(this.name, config.commodities.range, config.commodities.minRCL);
   if (!baseRoomName) {
     this.debugLog('commodities', 'No room for commodity farming found');
     return;

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -227,13 +227,24 @@ const getLines = function(room) {
   const storedE = room.storage ? room.storage.store[RESOURCE_ENERGY] : 0;
   const queueL = room.memory.queue ? room.memory.queue.length : 0;
   const rclP = Math.floor(100 * (room.controller.progressTotal ? room.controller.progress / room.controller.progressTotal : 1));
-
-  const lines = [
-    {label: `Energy Average :`, value: energy, coefficient: energy / room.energyCapacityAvailable},
-    {label: `Stored Energy :`, value: storedE, coefficient: Math.min(storedE, 500000) / 500000},
-    {label: `Queue length :`, value: queueL, coefficient: (20 - Math.min(queueL, 20)) / 20},
-    {label: `RCL ${room.controller.level} progress :`, value: rclP, coefficient: rclP / 100},
-  ];
+  const role = room.memory.queue ? room.memory.queue[0] ? room.memory.queue[0].role : '' : '';
+  let lines;
+  if (role !== '') {
+    lines = [
+      {label: `Energy Average :`, value: energy, coefficient: energy / room.energyCapacityAvailable},
+      {label: `Stored Energy :`, value: storedE, coefficient: Math.min(storedE, 500000) / 500000},
+      {label: `Queue length :`, value: queueL, coefficient: (20 - Math.min(queueL, 20)) / 20},
+      {label: `1st Role/Queue :`, value: role, coefficient: role},
+      {label: `RCL ${room.controller.level} progress :`, value: rclP, coefficient: rclP / 100},
+    ];
+  } else {
+    lines = [
+      {label: `Energy Average :`, value: energy, coefficient: energy / room.energyCapacityAvailable},
+      {label: `Stored Energy :`, value: storedE, coefficient: Math.min(storedE, 500000) / 500000},
+      {label: `Queue length :`, value: queueL, coefficient: (20 - Math.min(queueL, 20)) / 20},
+      {label: `RCL ${room.controller.level} progress :`, value: rclP, coefficient: rclP / 100},
+    ];
+  }
   return lines;
 };
 


### PR DESCRIPTION
- respawnMe

improvement for room visuals:
- added `1st Role/Queue`

fixes:
- handleReviveRoomQueueCarry: controller level should be at level 2 or above
- isConstructingSpawnEmergency: wrong order => set value before reading it
- checkForRoute: should use highway
- reviveMyNow: do not send nextroomer if there are hostiles => less energy waste
- some spaces
- typo/missing spaces in prototype_room_find.js
- harvestCommodities: move minRCL and range to config
- findAttackCreeps: do not attack friends
- ttl in creep queue, higher controller level => shorter ttl
- typo/missing spaces in prototype_room_costmatrix.js
- useHighway more often for carry, claimer and nextroomer
- avoid hostile rooms
- repairer found energy behind a wall, can not pickup
- new line before: module.exports
- hostileCreepCount not found
- suppress Deleting from memory for empty objects