### PR TITLE
Include attacked creeps in the reputation

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -8,10 +8,6 @@
 `role`: is the role the creep will be, you can change this to any available role.
 `targetRoom`: is the creeps target room.
 
-Soon you can also use (somotaw/master)
-
-    startAutoSquad('roomFrom' , 'roomTo')
-
 ## Sending a Reserver to reserve a rooms controller: (This will also trigger Remote Mining in the room)
 
     Game.rooms.W81N49.memory.queue.push({role: 'reserver', routing: {targetRoom: 'W82N48', targetId: '5873bc0e11e3e4361b4d6fc3'}})
@@ -39,11 +35,3 @@ Provide extra message
 • Using the commands above you can also send sourcer, carry, defender etc. to certain rooms/targets.
 
 Soon there will be Squad attacks the Commands for those are: (somotaw/master)
-
-## Send a Squad of 3 Healers and 3 Structurers (only attack structures, good for walls/ramparts)
-
-    brain.startSquad('RoomFrom','RoomTo')
-
-## Send a Squad of 3 Healers and 1 MeleeAttacker (Attack everything)
-
-    brain.startMeleeSquad('RoomFrom','RoomTo')

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
       "no-return-assign": "error",
       "no-script-url": "error",
       "no-self-compare": "error",
+      "no-trailing-spaces": "error",
       "no-unused-expressions": "error",
       "no-useless-call": "error",
       "no-useless-concat": "error",

--- a/src/brain_memory.js
+++ b/src/brain_memory.js
@@ -164,16 +164,16 @@ function cleanRooms() {
     for (const name of Object.keys(Memory.rooms)) {
       // TODO lastSeen moved to global.data - so we should check this, also Memory.rooms should only exist for myRooms
       if (!Memory.rooms[name].lastSeen && Object.keys(Memory.rooms[name]).length > 0) {
-        console.log(`${Game.time} Deleting ${name} from memory no 'lastSeen' value, keys: ${JSON.stringify(Object.keys(Memory.rooms[name]))}`);
+        debugLog('memory', `Deleting ${name} from memory no 'lastSeen' value, keys: ${JSON.stringify(Object.keys(Memory.rooms[name]))}`);
         delete Memory.rooms[name];
         continue;
       }
       if (Memory.rooms[name].lastSeen < Game.time - config.room.lastSeenThreshold && Memory.myRooms.indexOf(name) < 0) {
-        console.log(Game.time, `Deleting ${name} from memory older than ${config.room.lastSeenThreshold}`);
+        debugLog('memory', `Deleting ${name} from memory older than ${config.room.lastSeenThreshold}`);
         delete Memory.rooms[name];
       }
       if (Memory.myRooms.indexOf(name) < 0) {
-        console.log(Game.time, `Deleting ${name} from memory, no myRoom ${JSON.stringify(Memory.rooms[name])}`);
+        debugLog('memory', `Deleting ${name} from memory, no myRoom ${JSON.stringify(Memory.rooms[name])}`);
         delete Memory.rooms[name];
       }
     }

--- a/src/brain_squadmanager.js
+++ b/src/brain_squadmanager.js
@@ -92,12 +92,12 @@ function addToQueue(spawns, roomNameFrom, roomNameTarget, squadName, queueLimit)
   }
 }
 /**
- * brain.startSquad used to attack player.rooms
+ * startSquad used to attack player.rooms
  *
  * @param {String} roomNameFrom
  * @param {String} roomNameAttack
  */
-brain.startSquad = function(roomNameFrom, roomNameAttack) {
+function startSquad(roomNameFrom, roomNameAttack) {
   const name = 'siegesquad-' + Math.random();
   const route = Game.map.findRoute(roomNameFrom, roomNameAttack);
   let target = roomNameFrom;
@@ -125,16 +125,17 @@ brain.startSquad = function(roomNameFrom, roomNameAttack) {
     action: 'move',
     moveTarget: target,
   };
-};
+}
+module.exports.startSquad = startSquad;
 
 /**
- * brain.startMeleeSquad use to clean rooms from invaders and players
+ * startMeleeSquad use to clean rooms from invaders and players
  *
  * @param {String} roomNameFrom
  * @param {String} roomNameAttack
  * @param {Array} [spawns]
  */
-brain.startMeleeSquad = function(roomNameFrom, roomNameAttack, spawns) {
+function startMeleeSquad(roomNameFrom, roomNameAttack, spawns) {
   const name = 'meleesquad-' + Math.random();
   const route = Game.map.findRoute(roomNameFrom, roomNameAttack);
   let target = roomNameFrom;
@@ -170,4 +171,5 @@ brain.startMeleeSquad = function(roomNameFrom, roomNameAttack, spawns) {
     action: 'move',
     moveTarget: target,
   };
-};
+}
+module.exports.startMeleeSquad = startMeleeSquad;

--- a/src/config.js
+++ b/src/config.js
@@ -88,6 +88,7 @@ global.config = {
     routing: false,
     brain: false,
     commodities: true,
+    memory: true,
   },
 
   tower: {
@@ -97,6 +98,7 @@ global.config = {
 
   autoAttack: {
     notify: true,
+    minAttackRCL: 6,
     timeBetweenAttacks: 2000,
     noReservedRoomMinMyRCL: 5,
     noReservedRoomInRange: 1,
@@ -232,7 +234,7 @@ global.config = {
       7: 8,
       8: 8,
     },
-    isHealthyStorageThreshold: 50000,
+    isHealthyStorageThreshold: 100000,
     handleNukeAttackInterval: 132,
     reviveEnergyCapacity: 1000,
     reviveEnergyAvailable: 1000,

--- a/src/prototype_creep.js
+++ b/src/prototype_creep.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {addToReputation} = require('./diplomacy');
+
 /**
  * The data property represent the current data of the creep stored on the heap
  */
@@ -109,12 +111,28 @@ Creep.prototype.checkForHandle = function() {
   return true;
 };
 
+Creep.prototype.handleAttacked = function() {
+  if (!this.data.lastHits) {
+    this.data.lastHits = this.hits;
+    return;
+  }
+  if (this.data.lastHits > this.hits) {
+    const hostileCreeps = this.room.findHostileAttackingCreeps();
+    for (const hostileCreep of hostileCreeps) {
+      addToReputation(hostileCreep.owner.username, this.hits - this.data.lastHits);
+    }
+  }
+  this.data.lastHits = this.hits;
+};
+
 Creep.prototype.handle = function() {
   this.memory.room = this.pos.roomName;
   if (!this.checkForHandle()) {
     return;
   }
   try {
+    this.handleAttacked();
+
     if (!this.unit()) {
       this.log('Unknown role suiciding');
       this.suicide();

--- a/src/prototype_room_external.js
+++ b/src/prototype_room_external.js
@@ -254,7 +254,6 @@ Room.prototype.harvestCommodities = function() {
     if (Memory.commodities[this.name].lastCheck + 1500 > Game.time) {
       return;
     }
-    // this.log(`I know this commodity already: ${JSON.stringify(Memory.commodities[this.name])}`);
     const sourcers = this.findMyCreepsOfRole('sourcers');
     if (sourcers.length > 0) {
       return;

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -518,7 +518,6 @@ Room.prototype.isHealthy = function() {
   if (this.isStruggling()) {
     return false;
   }
-  // TODO extract as config variable
   if (this.storage.store.energy < config.room.isHealthyStorageThreshold) {
     return false;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const {startAttack} = require('./diplomacy');
+
 /**
  * This module is used to allow player easy access to different actions on the NPC
  * like asking for reports, triggering attacks, ...
@@ -5,10 +7,27 @@
 
 global.utils = {
   /**
+   * Attack player
+   *
+   * @param {string} playerName
+   */
+  attack: (playerName) => {
+    const player = Memory.players[playerName];
+    if (!player) {
+      console.log('player not found');
+      return;
+    }
+    startAttack(player);
+  },
+  /**
    * Print out known players
    */
   printPlayers: function() {
-    console.log(JSON.stringify(Memory.players, null, 2));
+    for (const playerKey of Object.keys(Memory.players)) {
+      const player = Memory.players[playerKey];
+      console.log(`${player.name} rooms: ${Object.keys(player.rooms).length} level: ${player.level} counter: ${player.counter} reputation: ${player.reputation}`);
+    }
+    // console.log(JSON.stringify(Memory.players, null, 2));
   },
 
   /**


### PR DESCRIPTION
When a creep gets attacked (less hit points) all players within that room with attack creeps get impacted in the reputation.

Refactoring and cleaning up the diplomacy module.