### PR TITLE
Introduce `spawnIdle`

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -232,6 +232,7 @@ global.config = {
       7: 8,
       8: 8,
     },
+    reserveSpawnIdleThreshold: 0.05,
     isHealthyStorageThreshold: 50000,
     handleNukeAttackInterval: 132,
     reviveEnergyCapacity: 1000,

--- a/src/logging.js
+++ b/src/logging.js
@@ -6,7 +6,7 @@
  */
 function debugLog(type, ...messages) {
   if (config.debug[type]) {
-    console.log(`${Game.time} ${messages.join(' ')}`);
+    console.log(`${Game.time} ${type.rightPad(' ', 27)}: ${messages.join(' ')}`);
   }
 }
 

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -60,6 +60,12 @@ Room.prototype.myHandleRoom = function() {
     this.memory.queue = [];
   }
 
+  this.memory.spawnIdle = this.memory.spawnIdle || 0;
+  const spawnIdle = this.findMySpawns().reduce((previous, current) => {
+    return previous || !current.spawning;
+  }, false);
+  this.memory.spawnIdle = 0.99 * this.memory.spawnIdle + 0.01 * (spawnIdle ? 1 : 0);
+
   const hostiles = this.findEnemies();
   if (hostiles.length === 0) {
     delete this.memory.hostile;


### PR DESCRIPTION
Store for each of `myRooms` the time a spawn is idle. Include this in the reserver logic and restrict new reservation on a spawnIdle threshold.

Currently too many rooms are tried to be reservered, while the actual `reserver` creeps are queue due to busy spawns.
The `spawnIdle` check tackles this issue.