### PR TITLE
feat: implement strategic retreat by stopping controller upgrades when trapped

### DIFF
--- a/src/prototype_creep_startup_tasks.js
+++ b/src/prototype_creep_startup_tasks.js
@@ -164,6 +164,10 @@ function pickupNearbyEnergyAtController(creep) {
  */
 Creep.upgradeControllerTask = function(creep) {
   creep.creepLog('upgradeControllerTask');
+  // Stop all controller upgrades when trapped - let controller die
+  if (Memory.trapped && Memory.trapped.isTrapped) {
+    return false;
+  }
   if (creep.carry.energy === 0) {
     return false;
   }

--- a/src/prototype_room_my.js
+++ b/src/prototype_room_my.js
@@ -591,7 +591,9 @@ Room.prototype.executeRoomCheckBasicCreeps = function() {
     this.checkRoleToSpawn('storagefiller', 1, 'filler');
   }
   if (this.storage && this.storage.my && this.storage.store.energy > config.room.upgraderMinStorage && !this.memory.misplacedSpawn) {
-    this.checkRoleToSpawn('upgrader', 1, this.controller.id);
+    if (!Memory.trapped || !Memory.trapped.isTrapped) {
+      this.checkRoleToSpawn('upgrader', 1, this.controller.id);
+    }
   }
 };
 

--- a/src/role_upgrader.js
+++ b/src/role_upgrader.js
@@ -78,6 +78,10 @@ roles.upgrader.killPrevious = true;
 roles.upgrader.boostActions = ['upgradeController'];
 
 roles.upgrader.action = function(creep) {
+  // Stop upgrading when trapped - let controller die
+  if (Memory.trapped && Memory.trapped.isTrapped) {
+    return true;
+  }
   creep.mySignController();
   creep.spawnReplacement(1);
   if (!creep.room.controller.isAboutToDowngrade()) {


### PR DESCRIPTION
## Summary

Implements Task 2 of the trapped bot escape strategy (#732) - strategic retreat via controller downgrade.

When the bot is trapped (detected by #734):
- Stops spawning new upgrader creeps
- Blocks all controller upgrade tasks for existing creeps (upgrader, builder, nextroomer, universal)
- Allows controller to naturally downgrade to 0
- Triggers automatic respawn via existing `utils/respawner.js` system

## Changes

**Three simple checks added:**

1. `prototype_room_my.js:593-596` - Block upgrader spawning when trapped
2. `prototype_creep_startup_tasks.js:167-170` - Stop `Creep.upgradeControllerTask` when trapped
3. `role_upgrader.js:81-84` - Stop upgrader role action when trapped

## Behavior

When `Memory.trapped.isTrapped === true`:
- ✅ No new upgraders spawn
- ✅ All controller upgrade tasks return early
- ✅ Controller downgrades naturally over time
- ✅ Energy automatically redirects to military/maintenance
- ✅ Room death triggers automatic respawn

## Integration

- Works with existing trapped detection (#734)
- Coordinates with future military response (#736)
- Uses existing respawn system (no new infrastructure)
- Simple, no configuration needed

## Testing

- ✅ ESLint passed
- ✅ All unit tests passed (6/6 including upgrader tests)
- Private server test has pre-existing permission error (unrelated)

Closes #735