### PR TITLE
fix: prevent mineral and squad infinite loops

### DIFF
--- a/src/role_mineral.js
+++ b/src/role_mineral.js
@@ -348,7 +348,7 @@ function setStatePrepareReactionLab1WithResource(creep) {
     return false;
   }
   // Check if terminal actually has the required resource
-  if (!creep.room.terminal || !creep.room.terminal.store[reaction.result.first] || creep.room.terminal.store[reaction.result.first] === 0) {
+  if (!creep.room.terminal || !creep.room.terminal.store[reaction.result.first] || creep.room.terminal.store[reaction.result.first] < LAB_REACTION_AMOUNT) {
     return false;
   }
   creep.data.state = {
@@ -378,7 +378,7 @@ function setStatePrepareReactionLab2WithResource(creep) {
     return false;
   }
   // Check if terminal actually has the required resource
-  if (!creep.room.terminal || !creep.room.terminal.store[reaction.result.second] || creep.room.terminal.store[reaction.result.second] === 0) {
+  if (!creep.room.terminal || !creep.room.terminal.store[reaction.result.second] || creep.room.terminal.store[reaction.result.second] < LAB_REACTION_AMOUNT) {
     return false;
   }
   creep.data.state = {
@@ -492,9 +492,13 @@ function handleWithdrawFromSource(creep) {
   }
   creep.moveToMy(source.pos);
   const resource = creep.data.state.getResource(source);
-  if (!resource) {
-    creep.log(`No resource available from ${source}, clearing state`);
+  if (!resource || !source.store[resource] || source.store[resource] < LAB_REACTION_AMOUNT) {
+    creep.log(`No sufficient resource available from ${source}, clearing state and reaction`);
     delete creep.data.state;
+    // Also clear the room's reaction to prevent immediate re-setting
+    if (creep.room.memory.reaction) {
+      delete creep.room.memory.reaction;
+    }
     return true;
   }
   const response = creep.withdraw(source, resource);

--- a/src/role_squadheal.js
+++ b/src/role_squadheal.js
@@ -47,15 +47,14 @@ roles.squadheal.preMove = function(creep, directions) {
   }
 };
 
-// TODO need to check if it works
 roles.squadheal.action = function(creep) {
   creep.selfHeal();
   if (creep.room.name !== creep.memory.routing.targetRoom) {
-    // creep.log('Not in room');
+    // Not in target room yet - traveling
     if (creep.hits < creep.hitsMax) {
       creep.moveRandom();
-    } else {
-      // creep.log('delete?');
+    } else if (!creep.pos.isBorder(-1)) {
+      // Only reset routing if not at border to prevent bouncing
       delete creep.memory.routing.reached;
     }
     return true;

--- a/src/role_squadsiege.js
+++ b/src/role_squadsiege.js
@@ -76,15 +76,20 @@ roles.squadsiege.preMove = function(creep, directions) {
   return false;
 };
 
-// TODO need to check if it works
 roles.squadsiege.action = function(creep) {
   creep.say('action');
+
   if (creep.room.name !== creep.memory.routing.targetRoom) {
+    // Not in target room yet - traveling
     if (creep.hits < creep.hitsMax) {
       creep.moveRandom();
-    } else {
+    } else if (!creep.pos.isBorder(-1)) {
+      // Only reset routing if not at border to prevent bouncing
       delete creep.memory.routing.reached;
     }
+    return true; // Don't execute siege when traveling
   }
+
+  // In target room - execute siege action
   return creep.siege();
 };


### PR DESCRIPTION
## Summary

This PR fixes two critical infinite loop issues that were wasting CPU every tick:

1. **Mineral Creep Infinite Loop** (continuation of PR #745)
2. **Squad Bouncing at Room Borders** (new issue discovered during investigation)

---

## Problem 1: Mineral Creep Infinite Loop

### Issue
After PR #745, mineral creeps were still experiencing infinite loops when:
- Terminal has 1-4 units of a required mineral
- `setState` validation checks for `=== 0` (passes with 1-4 units)
- Withdrawal attempt fails because amount < `LAB_REACTION_AMOUNT` (5)
- State gets cleared but immediately re-set on the same tick
- Loop continues wasting CPU every tick

Example log spam:
```
66153220 E17S52 mineral-121727 [room E17S52 pos 23,11] setStatePrepareReactionLab1WithResource
66153220 E17S52 mineral-121727 [room E17S52 pos 23,11] No resource available from terminal, clearing state
```

### Root Cause
1. **Inconsistent validation**: `setState` functions checked for `=== 0` while room cleanup logic checked for `< LAB_REACTION_AMOUNT`
2. **No reaction cleanup on failure**: When withdrawal failed, only the creep state was cleared but not the room's reaction memory
3. **Same-tick re-setting**: After state clearing, the state machine would immediately try to set the same state again

### Changes (role_mineral.js)
1. **Fix validation thresholds** in `setStatePrepareReactionLab1WithResource()` and `setStatePrepareReactionLab2WithResource()`:
   - Changed check from `=== 0` to `< LAB_REACTION_AMOUNT`
   - Now consistent with room cleanup logic

2. **Add self-healing cleanup** in `handleWithdrawFromSource()`:
   - When resource is unavailable or insufficient, also delete `room.memory.reaction`
   - Prevents immediate re-setting of the same failed state
   - Enhanced validation to check resource amount against `LAB_REACTION_AMOUNT`

---

## Problem 2: Squad Bouncing at Room Borders

### Issue
Squad creeps (both `squadsiege` and `squadheal`) would bounce infinitely between room exits:
- Creeps: squadsiege-244091, squadsiege-755626
- Positions: E17S52(17,49) ↔ E17S53(17,0)
- Logging "Reached end of handling() why?" every tick
- `routing.reached = true` but they keep moving back and forth
- No damage taken (hitsLost: 0)

### Root Cause - The Bouncing Cycle
1. **Creep enters target room E17S53** at position (17,0) → sets `routing.reached = true`
2. **Creep moves back to E17S52** at border position (17,49) due to border tile instability
3. **Action function checks**: "Am I in target room?" → NO
4. **Deletes** `routing.reached` flag
5. **Routing system restarts**: "You need to go to E17S53!"
6. **Creep moves forward** to E17S53 again
7. **Repeat forever** → infinite CPU waste

The bug was in the action functions:
```javascript
// OLD BROKEN CODE
if (creep.room.name !== creep.memory.routing.targetRoom) {
  delete creep.memory.routing.reached; // ← Causes restart loop at borders
}
return creep.siege(); // ← Always executes, even when traveling
```

Problems:
- No explicit handling for being IN the target room
- Deletes routing flag when at border tiles (causes restart loop)  
- Always calls `siege()` regardless of room location
- Unlike heal role which had better if/else logic

### Changes (role_squadsiege.js and role_squadheal.js)
1. **Add explicit if/else logic** to separate traveling vs in-target-room behavior:
   - When not in target room: handle traveling, don't execute combat actions
   - When in target room: execute combat actions

2. **Add border protection** using `isBorder()` check:
   - Only reset `routing.reached` if not at border tile
   - Prevents bouncing at room edges
   - Stable transition between rooms

3. **Don't execute siege/heal when traveling**:
   - Return early when not in target room
   - Only execute combat logic when actually in target room

---

## Impact

### Before Fix
- **Mineral creeps**: Spamming logs every tick, wasting CPU on repeated state setting
- **Squad creeps**: Bouncing at borders, never reaching attack objective, wasting spawn resources

### After Fix
- **Mineral creeps**: Stop cleanly when resources depleted, self-healing reaction cleanup
- **Squad creeps**: Properly enter target room and begin attack, no more bouncing
- **CPU savings**: Eliminated continuous routing recalculations and state resets
- **Consistent validation**: All code paths use same thresholds and logic

## Testing

- [x] Verified mineral creep stops spamming logs when resources are depleted
- [x] Confirmed reaction gets properly cleared when resources insufficient
- [x] Normal mineral operations continue working when resources available
- [x] Squad creeps properly transition into target room without bouncing
- [x] Border protection prevents routing reset at room edges
- [x] Both siege and heal roles fixed for consistency

## Files Changed

- `src/role_mineral.js` - Mineral creep validation and cleanup
- `src/role_squadsiege.js` - Squad siege action logic with border protection
- `src/role_squadheal.js` - Squad heal action logic with border protection